### PR TITLE
[CLOUD-459] remove unused GCP permissions

### DIFF
--- a/docs/setup_installation/gcp/gcp_permissions.yml
+++ b/docs/setup_installation/gcp/gcp_permissions.yml
@@ -21,7 +21,6 @@ includedPermissions:
 - compute.instances.setLabels
 - compute.instances.setMetadata
 - compute.instances.setServiceAccount
-- compute.instances.setTags
 - compute.instances.start
 - compute.instances.stop
 - compute.instances.setMachineType


### PR DESCRIPTION
Fixes https://hopsworks.atlassian.net/browse/CLOUD-459

Needs https://hopsworks.atlassian.net/browse/CLOUD-336 to be merged