### PR TITLE
FSTORE-1106: inconsistencies in training dataset documentation

### DIFF
--- a/docs/user_guides/fs/feature_view/training-data.md
+++ b/docs/user_guides/fs/feature_view/training-data.md
@@ -101,7 +101,7 @@ To clean up unused training data, you can delete all training data or for a part
 feature_view.delete_training_dataset(version=1)
 
 # delete all training datasets
-feature_view.delete_training_dataset()
+feature_view.delete_all_training_datasets()
 ```
 It is also possible to keep the metadata and delete only the materialised files. Then you can recreate the deleted files by just specifying a version, and you get back the exact same dataset again. This is useful when you are running out of storage.
 ```python


### PR DESCRIPTION
Corrected the documentation in user guides for deleting all training data in feature view to the function delete_all_training_datasets()

Local Testing Screenshot

<img width="1718" alt="Local Testing FSTORE-1106" src="https://github.com/logicalclocks/logicalclocks.github.io/assets/152865565/ff53748c-3501-48db-a3a0-054c5ff3e135">

