### PR TITLE
[FSTORE-1967] Add frontend UI for logical time scheduling

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -4,5 +4,6 @@ MD033: false
 MD045: false
 MD046: false
 MD052: false
+MD012: false
 MD004:
   style: dash

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -8,7 +8,7 @@ A **batch feature pipeline** is a job that processes a *time slice of data* — 
 
 Two operating modes cover the common cases:
 
-- **Incremental** — the pipeline runs on a recurring schedule. Each run sees a fresh `[HOPS_START_TIME, HOPS_END_TIME)` derived from the cron interval. Use this for production pipelines.
+- **Incremental** — the pipeline runs on a recurring schedule. Each run sees a fresh `[HOPS_START_TIME, HOPS_END_TIME)` computed as offsets from the cron fire time. Use this for production pipelines.
 - **Backfill** — a one-shot run over an explicit absolute time window. Use this to populate history or re-process a specific interval after a bug fix.
 
 Both modes emit the same `HOPS_*` environment variables, so the same pipeline code handles both.
@@ -19,9 +19,9 @@ On every scheduled or backfill execution, Hopsworks injects:
 
 | Variable | Meaning |
 |---|---|
-| `HOPS_LOGICAL_DATE` | Start of the data interval (ISO-8601 UTC). For a cron schedule, this is the previous fire. |
-| `HOPS_START_TIME`   | `HOPS_LOGICAL_DATE + start_time_offset_seconds`. Default offset is 0, i.e. the interval start. |
-| `HOPS_END_TIME`     | `data_interval_end + end_time_offset_seconds`. Default offset is 0, i.e. the current fire. |
+| `HOPS_START_TIME`   | `cron_fire_time + start_time_offset_seconds`. Default offset is `-3600` (one hour before the fire). |
+| `HOPS_END_TIME`     | `cron_fire_time + end_time_offset_seconds`. Default offset is `0` (at the fire). |
+| `HOPS_LOGICAL_DATE` | Scheduler dedup key for this interval (Airflow-style start of interval = previous cron fire). |
 
 For a manual (non-scheduled) run, these variables are only set if you explicitly pass a time window via the UI or API (see [Backfill](#backfill-one-shot-absolute-window) below).
 
@@ -33,7 +33,7 @@ For a manual (non-scheduled) run, these variables are only set if you explicitly
 Create or edit a job and configure its schedule under **Advanced scheduling**. Typical settings for a batch feature pipeline:
 
 - `cron_expression` — how often to run (e.g. `0 0 * ? * * *` for hourly).
-- `start_time_offset_seconds` / `end_time_offset_seconds` — shift the window if you want the job to process something other than "the previous cron interval". Leave both at 0 for the default.
+- `start_time_offset_seconds` / `end_time_offset_seconds` — seconds added to the cron fire time to produce the data window. Defaults are `-3600` / `0`, i.e. the previous hour. For a daily window, use `-86400` / `0`.
 - `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
 - `max_active_runs` — raise above 1 if runs can safely execute in parallel.
 

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -109,6 +109,7 @@ from datetime import UTC, datetime, timedelta
 
 import hopsworks
 
+
 project = hopsworks.login()
 job = project.get_job_api().get_job("my_feature_pipeline")
 

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -18,9 +18,9 @@ Both modes emit the same `HOPS_*` environment variables, so the same pipeline co
 On every scheduled or backfill execution, Hopsworks injects:
 
 | Variable | Meaning |
-|---|---|
-| `HOPS_START_TIME`   | `start_time_offset_seconds = null` *(default)* → previous cron fire (last execution time). Positive integer → `previous fire − seconds` (shifts the start earlier). Must be ≥ 0. |
-| `HOPS_END_TIME`     | Always `HOPS_START_TIME + cron interval` so consecutive runs tile the timeline with no gaps. `end_time_offset_seconds` is kept on the DTO for backward compatibility but ignored. |
+| --- | --- |
+| `HOPS_START_TIME` | `start_time_offset_seconds = null` *(default)* → previous cron fire (last execution time). Positive integer → `previous fire − seconds` (shifts the start earlier). Must be ≥ 0. |
+| `HOPS_END_TIME` | Always `HOPS_START_TIME + cron interval` so consecutive runs tile the timeline with no gaps. `end_time_offset_seconds` is kept on the DTO for backward compatibility but ignored. |
 | `HOPS_LOGICAL_DATE` | Stable identifier for this interval (Airflow-style start of interval = previous cron fire). Used for dedup and retries. |
 
 For a manual (non-scheduled) run, these variables are only set if you explicitly pass a time window via the UI or API (see [Backfill](#backfill-one-shot-absolute-window) below).
@@ -37,24 +37,30 @@ Create or edit a job and configure its schedule under **Advanced scheduling**. T
 - `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
 - `max_active_runs` — raise above 1 if runs can safely execute in parallel.
 
-See [How to schedule a job](./schedule_job.md#scheduling-fields) for the full field reference.
+See [How to schedule a job][scheduling-fields] for the full field reference.
 
 ### Reading the interval in your code
 
 ```python
 import os
 from datetime import datetime
+
 import hopsworks
+
 
 project = hopsworks.login()
 fs = project.get_feature_store()
 fg = fs.get_feature_group("page_views", version=1)
+source = fs.get_storage_connector("my_source")
 
 start = datetime.fromisoformat(os.environ["HOPS_START_TIME"])
-end   = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
+end = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
 
-df = source.query(
-    f"SELECT * FROM events WHERE ts >= '{start.isoformat()}' AND ts < '{end.isoformat()}'"
+df = source.read(
+    query=(
+        "SELECT * FROM events "
+        f"WHERE ts >= '{start.isoformat()}' AND ts < '{end.isoformat()}'"
+    ),
 )
 fg.insert(df)
 ```
@@ -72,35 +78,42 @@ On the job's **Run** dialog, tick **Run with time window (one-shot backfill)** a
 ### From the Python SDK
 
 ```python
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+
 import hopsworks
+
 
 project = hopsworks.login()
 job = project.get_job_api().get_job("my_feature_pipeline")
 
 # Backfill March 2026
 job.run(
-    start_time=datetime(2026, 3, 1, tzinfo=timezone.utc),
-    end_time=datetime(2026, 4, 1, tzinfo=timezone.utc),
+    start_time=datetime(2026, 3, 1, tzinfo=UTC),
+    end_time=datetime(2026, 4, 1, tzinfo=UTC),
 )
 ```
 
 `Job.run()` accepts the following optional logical-time kwargs:
 
 | kwarg | Maps to |
-|---|---|
+| --- | --- |
 | `start_time` | `HOPS_START_TIME` + `logical_date` (data interval start) |
-| `end_time`   | `HOPS_END_TIME` + `data_interval_end` |
+| `end_time` | `HOPS_END_TIME` + `data_interval_end` |
 | `logical_date` | Override `HOPS_LOGICAL_DATE` independently (rare). |
 | `env_vars` | Arbitrary per-run env vars; highest precedence. |
 
 ### Chained monthly backfill
 
 ```python
-from datetime import datetime, timezone, timedelta
+from datetime import UTC, datetime, timedelta
 
-start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-end = datetime(2026, 1, 1, tzinfo=timezone.utc)
+import hopsworks
+
+project = hopsworks.login()
+job = project.get_job_api().get_job("my_feature_pipeline")
+
+start = datetime(2024, 1, 1, tzinfo=UTC)
+end = datetime(2026, 1, 1, tzinfo=UTC)
 
 cursor = start
 while cursor < end:
@@ -131,5 +144,5 @@ So setting `HOPS_END_TIME` in the Environment variables panel pins it for every 
 
 ## See also
 
-- [Schedule a job](./schedule_job.md) — full reference for cron + advanced scheduling fields.
-- [Python job](./python_job.md) / [Spark job](./spark_job.md) — adding generic env vars to a job configuration.
+- [Schedule a job][how-to-schedule-a-job] — full reference for cron + advanced scheduling fields.
+- [Python job][how-to-run-a-python-job] / [Spark job][how-to-run-a-spark-job] — adding generic env vars to a job configuration.

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -1,0 +1,126 @@
+---
+description: How to build and run batch feature pipelines on Hopsworks using logical-time scheduling and backfill runs.
+---
+
+# Batch Feature Pipelines
+
+A **batch feature pipeline** is a job that processes a *time slice of data* — for example "the rows for the previous hour" or "every day's transactions" — and writes the resulting features to a feature group. Hopsworks jobs carry this time slice as environment variables so your code does not need to guess the window from wall-clock time.
+
+Two operating modes cover the common cases:
+
+- **Incremental** — the pipeline runs on a recurring schedule. Each run sees a fresh `[HOPS_START_TIME, HOPS_END_TIME)` derived from the cron interval. Use this for production pipelines.
+- **Backfill** — a one-shot run over an explicit absolute time window. Use this to populate history or re-process a specific interval after a bug fix.
+
+Both modes emit the same `HOPS_*` environment variables, so the same pipeline code handles both.
+
+## Environment variables
+
+On every scheduled or backfill execution, Hopsworks injects:
+
+| Variable | Meaning |
+|---|---|
+| `HOPS_LOGICAL_DATE` | Start of the data interval (ISO-8601 UTC). For a cron schedule, this is the previous fire. |
+| `HOPS_START_TIME`   | `HOPS_LOGICAL_DATE + start_time_offset_seconds`. Default offset is 0, i.e. the interval start. |
+| `HOPS_END_TIME`     | `data_interval_end + end_time_offset_seconds`. Default offset is 0, i.e. the current fire. |
+
+For a manual (non-scheduled) run, these variables are only set if you explicitly pass a time window via the UI or API (see [Backfill](#backfill-one-shot-absolute-window) below).
+
+!!! tip "User-defined env vars override the scheduler"
+    If you set `HOPS_START_TIME` or `HOPS_END_TIME` in the job's envVars (or at launch time), your value wins over the scheduler-computed one for that execution. This is how backfill runs override the cron-derived interval.
+
+## Incremental (recurring)
+
+Create or edit a job and configure its schedule under **Advanced scheduling**. Typical settings for a batch feature pipeline:
+
+- `cron_expression` — how often to run (e.g. `0 0 * ? * * *` for hourly).
+- `start_time_offset_seconds` / `end_time_offset_seconds` — shift the window if you want the job to process something other than "the previous cron interval". Leave both at 0 for the default.
+- `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
+- `max_active_runs` — raise above 1 if runs can safely execute in parallel.
+
+See [How to schedule a job](./schedule_job.md#advanced-scheduling) for the full field reference.
+
+### Reading the interval in your code
+
+```python
+import os
+from datetime import datetime
+import hopsworks
+
+project = hopsworks.login()
+fs = project.get_feature_store()
+fg = fs.get_feature_group("page_views", version=1)
+
+start = datetime.fromisoformat(os.environ["HOPS_START_TIME"])
+end   = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
+
+df = source.query(
+    f"SELECT * FROM events WHERE ts >= '{start.isoformat()}' AND ts < '{end.isoformat()}'"
+)
+fg.insert(df)
+```
+
+This code works identically whether the job runs on its schedule or as a one-shot backfill.
+
+## Backfill (one-shot, absolute window)
+
+Use backfill when you need to re-process historical data or seed a feature group before turning on the incremental schedule. No schedule change is required — you supply the window at launch time.
+
+### From the UI
+
+On the job's **Run** dialog, tick **Run with time window (one-shot backfill)** and pick the `HOPS_START_TIME` / `HOPS_END_TIME` datetimes (UTC). The execution is submitted with those env vars set; any schedule-derived values are overridden for this run.
+
+### From the Python SDK
+
+```python
+from datetime import datetime, timezone
+import hopsworks
+
+project = hopsworks.login()
+job = project.get_job_api().get_job("my_feature_pipeline")
+
+# Backfill March 2026
+job.run(
+    start_time=datetime(2026, 3, 1, tzinfo=timezone.utc),
+    end_time=datetime(2026, 4, 1, tzinfo=timezone.utc),
+)
+```
+
+`Job.run()` accepts the following optional logical-time kwargs:
+
+| kwarg | Maps to |
+|---|---|
+| `start_time` | `HOPS_START_TIME` + `logical_date` (data interval start) |
+| `end_time`   | `HOPS_END_TIME` + `data_interval_end` |
+| `logical_date` | Override `HOPS_LOGICAL_DATE` independently (rare). |
+| `env_vars` | Arbitrary per-run env vars; highest precedence. |
+
+### Chained monthly backfill
+
+```python
+from datetime import datetime, timezone, timedelta
+
+start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+end = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+cursor = start
+while cursor < end:
+    nxt = (cursor.replace(day=1) + timedelta(days=32)).replace(day=1)
+    job.run(start_time=cursor, end_time=nxt, await_termination=True)
+    cursor = nxt
+```
+
+## Precedence summary
+
+Several sources can set the same env var. The rule is "most specific wins":
+
+1. **Per-execution env vars** supplied to `job.run(env_vars=...)` or the UI time-window dialog.
+2. **Job-config env vars** (the Environment variables panel on the Advanced job form).
+3. **Scheduler-computed** `HOPS_*` from the data interval + offsets.
+4. **Hopsworks defaults** (e.g. `HADOOP_HOME`).
+
+So setting `HOPS_END_TIME` in the Environment variables panel pins it for every execution of the job; passing `env_vars={"HOPS_END_TIME": "..."}` to a single `job.run()` pins it only for that run.
+
+## See also
+
+- [Schedule a job](./schedule_job.md) — full reference for cron + advanced scheduling fields.
+- [Python job](./python_job.md) / [Spark job](./spark_job.md) — adding generic env vars to a job configuration.

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -37,7 +37,7 @@ Create or edit a job and configure its schedule under **Advanced scheduling**. T
 - `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
 - `max_active_runs` — raise above 1 if runs can safely execute in parallel.
 
-See [How to schedule a job](./schedule_job.md#advanced-scheduling) for the full field reference.
+See [How to schedule a job](./schedule_job.md#scheduling-fields) for the full field reference.
 
 ### Reading the interval in your code
 

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -19,9 +19,9 @@ On every scheduled or backfill execution, Hopsworks injects:
 
 | Variable | Meaning |
 |---|---|
-| `HOPS_START_TIME`   | Default `null` → previous cron fire (last execution time). Explicit int → `cron_fire + seconds` (negative = before, positive = after). |
-| `HOPS_END_TIME`     | Default `null` → cron fire time. Explicit int → `cron_fire + seconds`. |
-| `HOPS_LOGICAL_DATE` | Scheduler dedup key for this interval (Airflow-style start of interval = previous cron fire). |
+| `HOPS_START_TIME`   | `start_time_offset_seconds = null` *(default)* → previous cron fire (last execution time). Positive integer → `previous fire − seconds` (shifts the start earlier). Must be ≥ 0. |
+| `HOPS_END_TIME`     | Always `HOPS_START_TIME + cron interval` so consecutive runs tile the timeline with no gaps. `end_time_offset_seconds` is kept on the DTO for backward compatibility but ignored. |
+| `HOPS_LOGICAL_DATE` | Stable identifier for this interval (Airflow-style start of interval = previous cron fire). Used for dedup and retries. |
 
 For a manual (non-scheduled) run, these variables are only set if you explicitly pass a time window via the UI or API (see [Backfill](#backfill-one-shot-absolute-window) below).
 
@@ -33,7 +33,7 @@ For a manual (non-scheduled) run, these variables are only set if you explicitly
 Create or edit a job and configure its schedule under **Advanced scheduling**. Typical settings for a batch feature pipeline:
 
 - `cron_expression` — how often to run (e.g. `0 0 * ? * * *` for hourly).
-- `start_time_offset_seconds` / `end_time_offset_seconds` — default `null` gives the natural cron interval (previous fire → current fire). Set explicit seconds (negative = before fire, positive = after fire) if you need a different window.
+- `start_time_offset_seconds` — default `null` gives the natural cron interval (`[previous fire, current fire)`). Set a positive integer to anchor the window earlier than the previous fire (e.g. `3600` makes each run see the window starting an hour before its predecessor); the window remains exactly one cron interval wide because `HOPS_END_TIME = HOPS_START_TIME + cron interval`.
 - `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
 - `max_active_runs` — raise above 1 if runs can safely execute in parallel.
 
@@ -108,6 +108,15 @@ while cursor < end:
     job.run(start_time=cursor, end_time=nxt, await_termination=True)
     cursor = nxt
 ```
+
+### Batched backfill at job creation
+
+When creating a new job in the UI, the **Backfill** card lets you split one window into **N equal sub-windows** and fire one execution per sub-window. Tick *Run job on creation* to have the sub-windows fired as soon as the job is saved:
+
+- **Number of Batch Jobs** — how many sub-windows. `[start, end)` is tiled with no gaps or overlaps; the last sub-window absorbs any integer-division remainder so the union is exactly the original window. `1` means one execution covering the whole window (the default).
+- **Max parallel executions** — must be `≥ Number of Batch Jobs` today. Runtime concurrency enforcement (pause the next batch until a running one completes) is on the roadmap; until then the backend rejects smaller values with a `400` rather than silently over-firing. Setting it equal to the batch count fires everything in parallel.
+
+Each sub-window run receives `HOPS_START_TIME` / `HOPS_END_TIME` for its slice, so the same pipeline code used by the incremental schedule works unchanged.
 
 ## Precedence summary
 

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -19,8 +19,8 @@ On every scheduled or backfill execution, Hopsworks injects:
 
 | Variable | Meaning |
 |---|---|
-| `HOPS_START_TIME`   | `cron_fire_time + start_time_offset_seconds`. Default offset is `-3600` (one hour before the fire). |
-| `HOPS_END_TIME`     | `cron_fire_time + end_time_offset_seconds`. Default offset is `0` (at the fire). |
+| `HOPS_START_TIME`   | Default `null` → previous cron fire (last execution time). Explicit int → `cron_fire + seconds` (negative = before, positive = after). |
+| `HOPS_END_TIME`     | Default `null` → cron fire time. Explicit int → `cron_fire + seconds`. |
 | `HOPS_LOGICAL_DATE` | Scheduler dedup key for this interval (Airflow-style start of interval = previous cron fire). |
 
 For a manual (non-scheduled) run, these variables are only set if you explicitly pass a time window via the UI or API (see [Backfill](#backfill-one-shot-absolute-window) below).
@@ -33,7 +33,7 @@ For a manual (non-scheduled) run, these variables are only set if you explicitly
 Create or edit a job and configure its schedule under **Advanced scheduling**. Typical settings for a batch feature pipeline:
 
 - `cron_expression` — how often to run (e.g. `0 0 * ? * * *` for hourly).
-- `start_time_offset_seconds` / `end_time_offset_seconds` — seconds added to the cron fire time to produce the data window. Defaults are `-3600` / `0`, i.e. the previous hour. For a daily window, use `-86400` / `0`.
+- `start_time_offset_seconds` / `end_time_offset_seconds` — default `null` gives the natural cron interval (previous fire → current fire). Set explicit seconds (negative = before fire, positive = after fire) if you need a different window.
 - `catchup` — on by default *off*. Enable it if missed runs during an outage should be replayed one-per-missed-interval.
 - `max_active_runs` — raise above 1 if runs can safely execute in parallel.
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -92,6 +92,9 @@ It is possible to also set following configuration settings for a `PYTHON` job.
 - `Additional files`: List of files that will be locally accessible in the working directory of the application.
   Only recommended to use if project datasets are not mounted under `/hopsfs`.
   You can always modify the arguments in the job settings.
+- `Environment variables`: Custom `KEY=VALUE` pairs that are set on the container for every
+  execution of this job. Read them in your Python code with `os.environ["MY_KEY"]`. See
+  [Environment variables](#environment-variables) below.
 
 <p align="center">
   <figure>
@@ -209,6 +212,30 @@ The project datasets are mounted under `/hopsfs`, so you can access `data.csv` f
 The script's working directory is the folder it is located in.
 For example, if it is located in the `Resources` dataset, and you have a file named `data.csv` in that dataset, you simply access it using `data.csv`.
 Also, if you write a local file, for example `output.txt`, it will be saved in the `Resources` dataset.
+
+## Environment variables
+
+User-defined environment variables can be attached to a Python job under the
+*Environment variables* panel of the advanced configuration. Each entry is a
+`KEY=VALUE` pair that is set on the container for every execution of the job.
+
+```python
+# inside your Python job script
+import os
+
+api_key = os.environ["MY_API_KEY"]
+region  = os.environ.get("AWS_REGION", "us-east-1")
+```
+
+Scheduled and backfill runs also receive `HOPS_LOGICAL_DATE`, `HOPS_START_TIME`
+and `HOPS_END_TIME` describing the data interval they should process — see
+[Scheduling](./schedule_job.md#logical-time-and-data-intervals) and
+[Batch feature pipelines](./batch_feature_pipeline.md).
+
+!!! warning "Reserved names"
+    Names starting with `HOPS_` are reserved by the scheduler. Setting them in
+    the *Environment variables* panel overrides the scheduler value for every
+    execution — the UI shows a warning callout when you do this.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -159,7 +159,6 @@ py_job_config["appPath"] = uploaded_file_path
 py_job_config["environmentName"] = "python-feature-pipeline"
 
 job = jobs_api.create_job("py_job", py_job_config)
-
 ```
 
 ### Step 3: Execute the job
@@ -178,7 +177,6 @@ print(f_out.read())
 
 f_err = open(err, "r")
 print(f_err.read())
-
 ```
 
 ## Configuration

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -159,6 +159,7 @@ py_job_config["appPath"] = uploaded_file_path
 py_job_config["environmentName"] = "python-feature-pipeline"
 
 job = jobs_api.create_job("py_job", py_job_config)
+
 ```
 
 ### Step 3: Execute the job
@@ -177,6 +178,7 @@ print(f_out.read())
 
 f_err = open(err, "r")
 print(f_err.read())
+
 ```
 
 ## Configuration
@@ -223,14 +225,16 @@ User-defined environment variables can be attached to a Python job under the
 # inside your Python job script
 import os
 
+
 api_key = os.environ["MY_API_KEY"]
-region  = os.environ.get("AWS_REGION", "us-east-1")
+region = os.environ.get("AWS_REGION", "us-east-1")
+print(f"Using {api_key[:4]}*** in {region}")
 ```
 
 Scheduled and backfill runs also receive `HOPS_LOGICAL_DATE`, `HOPS_START_TIME`
 and `HOPS_END_TIME` describing the data interval they should process — see
-[Scheduling](./schedule_job.md#logical-time-and-data-intervals) and
-[Batch feature pipelines](./batch_feature_pipeline.md).
+[Scheduling][logical-time-and-data-intervals] and
+[Batch feature pipelines][batch-feature-pipelines].
 
 !!! warning "Reserved names"
     Names starting with `HOPS_` are reserved by the scheduler. Setting them in

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -26,15 +26,11 @@ Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](
 
 When the scheduler fires a job, it attaches a **data window** to the execution, expressed through three environment variables:
 
-- `HOPS_START_TIME` — start of the data window. Three modes:
-    - **Last execution time** *(default)* — the previous cron fire. This adapts to the schedule's cadence, so the window is always "everything since the previous run".
-    - **Before cron fire (hh:mm)** — `cron_fire - (hh*3600 + mm*60)` seconds.
-    - **After cron fire (hh:mm)** — `cron_fire + (hh*3600 + mm*60)` seconds.
-- `HOPS_END_TIME` — end of the data window. Three modes:
-    - **Cron fire time** *(default)* — the current fire.
-    - **Before cron fire (hh:mm)**.
-    - **After cron fire (hh:mm)**.
-- `HOPS_LOGICAL_DATE` — the scheduler's dedup key for this interval (Airflow-style *start of interval* = previous cron fire). Useful as a stable identifier for the run.
+- `HOPS_START_TIME` — start of the data window. Two modes:
+    - **Last execution time** *(default — `start_time_offset_seconds = null`)* — the previous cron fire. Adapts to the schedule's cadence, so the window is always "everything since the previous run".
+    - **Before last execution (hh:mm)** — `previous_fire − (hh*3600 + mm*60)` seconds. Stored as a positive integer; the backend subtracts.
+- `HOPS_END_TIME` — end of the data window. **Always `HOPS_START_TIME + cron interval`** so consecutive scheduled runs tile the timeline with no gaps between them. `end_time_offset_seconds` is kept on the DTO for backward compatibility but is ignored.
+- `HOPS_LOGICAL_DATE` — the scheduler's stable identifier for this interval (Airflow-style *start of interval* = previous cron fire). Used for dedup and retries.
 
 With the defaults on an hourly schedule firing at 10:00, the window is `[09:00, 10:00)` — the last hour of data. The same defaults on a daily schedule firing at 00:00 give `[yesterday 00:00, today 00:00)` — the last day. Change the modes (see below) to shape a different window.
 
@@ -111,26 +107,22 @@ The Schedule form exposes these fields for controlling the data window, concurre
 | Field | Default | Description |
 |---|---|---|
 | `max_active_runs` | `1` | Upper bound on concurrent executions for this job. |
-| `start_time_offset_seconds` | `null` *(last execution time)* | `null` → `HOPS_START_TIME` = previous cron fire. Integer → `cron_fire + seconds` (negative = before, positive = after). |
-| `end_time_offset_seconds` | `null` *(cron fire time)* | `null` → `HOPS_END_TIME` = cron fire time. Integer → `cron_fire + seconds`. |
+| `start_time_offset_seconds` | `null` *(last execution time)* | `null` → `HOPS_START_TIME = previous cron fire`. Positive integer → `HOPS_START_TIME = previous fire − seconds` (shifts the window earlier). Must be ≥ 0. |
+| `end_time_offset_seconds` | *legacy; ignored* | Kept on the DTO for backward compatibility. The backend always sets `HOPS_END_TIME = HOPS_START_TIME + cron interval` — consecutive runs tile the timeline with no gaps. |
 | `catchup` | `false` | If `true`, on recovery after a scheduler outage the runs for every missed interval are created. If `false`, only the most recent missed interval is created. |
 | `skip_to_date` | *unset* | When `catchup=true`, missed intervals strictly before this date are skipped during reconciliation. |
 | `max_catchup_runs` | *unset* | When `catchup=true`, caps how many missed intervals are replayed, keeping the most recent. |
 
-**Example — "process the previous day, not the previous hour"**
+**Example — "process the previous 25 hours, not the previous hour"**
 
-Defaults give you the natural cron interval (`[previous fire, current fire)`). To process yesterday's data every hour instead, pick explicit offsets (25 h and 24 h before fire):
+Defaults give you the natural cron interval (`[previous fire, current fire)`). To process a 25-hour trailing window every hour (e.g. to include a little overlap for late-arriving data), shift `start` 24 hours earlier — the end stays at the current fire because it's `start + cron interval = start + 1 h`:
 
 ```
-start_time_offset_seconds = -25 * 3600   # fire - 25 h
-end_time_offset_seconds   = -24 * 3600   # fire - 24 h
+start_time_offset_seconds = 25 * 3600   # HOPS_START_TIME = previous fire − 25 h
+# end_time_offset_seconds is ignored; HOPS_END_TIME = HOPS_START_TIME + 1 h
 ```
 
-At 11:00 UTC the container sees `HOPS_START_TIME = 10:00 (previous day)` and `HOPS_END_TIME = 11:00 (previous day)`.
-
-**Example — window ending in the future**
-
-Positive offsets look forward. `start_time_offset_seconds = 0`, `end_time_offset_seconds = 3600` produces a window from the fire time to one hour after — useful when the pipeline reads forecasts rather than history.
+At 11:00 UTC on an hourly schedule the container sees `HOPS_START_TIME = 09:00 (previous day)` and `HOPS_END_TIME = 10:00 (previous day)`.
 
 **Example — `catchup=false` after a 6-hour outage**
 
@@ -168,11 +160,12 @@ job.schedule(
     start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
 )
 
-# Fixed 2-hour window ending at the cron fire:
+# Shift the window 1 hour earlier so each hourly run sees the previous-to-previous
+# hour. HOPS_END_TIME is always HOPS_START_TIME + cron interval (1 h here), so the
+# window remains 1 hour wide — only the anchor moves.
 job.schedule(
     cron_expression="0 0 * ? * * *",
-    start_time_offset_seconds=-2 * 3600,
-    end_time_offset_seconds=0,
+    start_time_offset_seconds=3600,   # previous fire − 1 h
     catchup=True,
     max_active_runs=2,
     max_catchup_runs=24,
@@ -223,5 +216,5 @@ This matches what most users expect ("turn on catchup ⇒ see the backfill"), bu
 
 ### Leader election via Payara, not advisory locks
 
-Airflow coordinates multiple schedulers with PostgreSQL advisory locks (`pg_try_advisory_xact_lock`). Hopsworks uses Payara's cluster primary election: the scheduler timer only fires on the primary node. Reconciliation happens on the first primary-owned tick after startup. Correctness is backed by a DB unique index on `(job_id, logical_date)`, so even during a leader failover window no duplicate runs are created.
+Airflow coordinates multiple schedulers with PostgreSQL advisory locks (`pg_try_advisory_xact_lock`). Hopsworks uses Payara's cluster primary election: the scheduler timer only fires on the primary node. Reconciliation happens on the first primary-owned tick after startup. Correctness is backed at the application layer — `executeWithCron` seeds `startingActive = countActiveByJob(...)` once per tick and tracks an additive `firedThisTick` counter, which is monotonic and independent of RonDB COUNT read-after-write lag. This replaces an earlier `(job_id, logical_date)` unique index that was too strict — it blocked legitimate retry / manual-rerun / re-backfill flows that share a logical_date.
 

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -26,11 +26,17 @@ Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](
 
 When the scheduler fires a job, it attaches a **data window** to the execution, expressed through three environment variables:
 
-- `HOPS_START_TIME` — start of the data window. Computed as `cron_fire_time + start_time_offset_seconds`. Default offset is **-3600** (one hour before the fire).
-- `HOPS_END_TIME`   — end of the data window. Computed as `cron_fire_time + end_time_offset_seconds`. Default offset is **0** (at the fire).
+- `HOPS_START_TIME` — start of the data window. Three modes:
+    - **Last execution time** *(default)* — the previous cron fire. This adapts to the schedule's cadence, so the window is always "everything since the previous run".
+    - **Before cron fire (hh:mm)** — `cron_fire - (hh*3600 + mm*60)` seconds.
+    - **After cron fire (hh:mm)** — `cron_fire + (hh*3600 + mm*60)` seconds.
+- `HOPS_END_TIME` — end of the data window. Three modes:
+    - **Cron fire time** *(default)* — the current fire.
+    - **Before cron fire (hh:mm)**.
+    - **After cron fire (hh:mm)**.
 - `HOPS_LOGICAL_DATE` — the scheduler's dedup key for this interval (Airflow-style *start of interval* = previous cron fire). Useful as a stable identifier for the run.
 
-With the defaults on an hourly schedule firing at 10:00, the window is `[09:00, 10:00)` — the last hour of data. Change the offsets (see below) to shape a different window.
+With the defaults on an hourly schedule firing at 10:00, the window is `[09:00, 10:00)` — the last hour of data. The same defaults on a daily schedule firing at 00:00 give `[yesterday 00:00, today 00:00)` — the last day. Change the modes (see below) to shape a different window.
 
 These three values are injected into the job container as **environment variables** on every scheduled execution. In your program, read them like any other env var:
 
@@ -105,15 +111,15 @@ The Schedule form exposes these fields for controlling the data window, concurre
 | Field | Default | Description |
 |---|---|---|
 | `max_active_runs` | `1` | Upper bound on concurrent executions for this job. |
-| `start_time_offset_seconds` | `-3600` | Seconds added to the cron fire time to produce `HOPS_START_TIME`. Negative values look backwards; positive values look forward. |
-| `end_time_offset_seconds` | `0` | Seconds added to the cron fire time to produce `HOPS_END_TIME`. |
+| `start_time_offset_seconds` | `null` *(last execution time)* | `null` → `HOPS_START_TIME` = previous cron fire. Integer → `cron_fire + seconds` (negative = before, positive = after). |
+| `end_time_offset_seconds` | `null` *(cron fire time)* | `null` → `HOPS_END_TIME` = cron fire time. Integer → `cron_fire + seconds`. |
 | `catchup` | `false` | If `true`, on recovery after a scheduler outage the runs for every missed interval are created. If `false`, only the most recent missed interval is created. |
 | `skip_to_date` | *unset* | When `catchup=true`, missed intervals strictly before this date are skipped during reconciliation. |
 | `max_catchup_runs` | *unset* | When `catchup=true`, caps how many missed intervals are replayed, keeping the most recent. |
 
 **Example — "process the previous day, not the previous hour"**
 
-Defaults give you the last hour (`[fire-1h, fire)`). To process yesterday's data every hour instead, shift both offsets back 24 hours:
+Defaults give you the natural cron interval (`[previous fire, current fire)`). To process yesterday's data every hour instead, pick explicit offsets (25 h and 24 h before fire):
 
 ```
 start_time_offset_seconds = -25 * 3600   # fire - 25 h
@@ -154,13 +160,15 @@ import hopsworks
 project = hopsworks.login()
 job = project.get_job_api().get_job("my_feature_pipeline")
 
-# Hourly. Defaults yield HOPS_START_TIME = fire - 1 h, HOPS_END_TIME = fire (the last hour).
+# Defaults (None, None): HOPS_START_TIME = previous cron fire (last execution time),
+# HOPS_END_TIME = cron fire time. Adapts to any cron — hourly gives the last hour,
+# daily gives the last day, etc.
 job.schedule(
     cron_expression="0 0 * ? * * *",
     start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
 )
 
-# Hourly, 2-hour window ending at the cron fire:
+# Fixed 2-hour window ending at the cron fire:
 job.schedule(
     cron_expression="0 0 * ? * * *",
     start_time_offset_seconds=-2 * 3600,

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -174,3 +174,40 @@ job.unschedule()
 ```
 
 See also [Batch feature pipelines](./batch_feature_pipeline.md) for one-shot backfill runs and the `Job.run(start_time=..., end_time=...)` API.
+
+## Differences from Apache Airflow
+
+Hopsworks follows the same [data-interval model as Airflow](https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/timetable.html): `logical_date` is the start of the data interval, `data_interval_end` is the cron fire time, runs are created at or after the interval end, and `catchup` controls whether missed intervals are replayed. However, a few behaviours differ — if you are coming from Airflow, these are the ones worth knowing.
+
+### First-run interval starts at `start_date`, not the next cron boundary
+
+If a schedule has `start_date = 10:05` and an hourly cron firing on `:00`, Airflow aligns `start_date` forward to `11:00` and the first run has `data_interval = [11:00, 12:00)`. Hopsworks clamps the previous fire to `start_date`, so the first run fires at `11:00` with `data_interval = [10:05, 11:00)` — a short first interval starting at `start_date` itself.
+
+If that offset would break the first run's computation (for example, a job that expects full hourly windows), set `start_date` to a cron-aligned time.
+
+### Manual runs don't automatically get a data interval
+
+Airflow always fills a data interval for manually triggered DagRuns via `infer_manual_data_interval`. Hopsworks sets `HOPS_LOGICAL_DATE` / `HOPS_START_TIME` / `HOPS_END_TIME` on a manual run **only if you explicitly pass them** — via the UI's *Run with time window* dialog, the Python `job.run(start_time=..., end_time=...)` kwargs, or the JSON execution endpoint. A plain "Run" with no time window leaves the env vars unset.
+
+This keeps the contract honest: a manual one-off either processes a specific window (opt in) or processes "whatever your code defines, independent of any window". It does mean job code shouldn't assume `HOPS_START_TIME` is always present — check for the var and fall back as appropriate.
+
+### Per-tick draining vs. one-per-loop
+
+Airflow's scheduler creates at most one DagRun per DAG per loop iteration, to keep many DAGs progressing in parallel. The Hopsworks scheduler will drain up to 20 past intervals for one schedule in a single timer tick (each tick is ~1 minute), then move on. In practice this means a schedule with a large backlog catches up in batches of 20 per minute rather than one per minute, while not blocking other schedules for more than one tick.
+
+You typically don't observe this unless `catchup=true` after a long outage: expect the backlog to drain at ~20 intervals/minute per schedule, not one.
+
+### No DST fold-hour handling
+
+Airflow treats cron schedules as timezone-aware and has explicit logic for the DST "fold hour" when clocks go back. Hopsworks evaluates schedules in UTC. If you need non-UTC semantics, express your cron in UTC — there is no equivalent of Airflow's timezone-aware timetable for DST. For almost all users this is a non-issue.
+
+### Reconciliation on schedule create / update, not just outage
+
+In Airflow, `catchup=true` kicks in only when the scheduler detects past intervals at runtime. Hopsworks also replays missed intervals at *creation* time — if you create a new schedule with `catchup=true` and a `start_date` in the past, past intervals run immediately rather than being implicitly skipped by the first-fire advancement. The same happens if you flip `catchup` from `false` to `true`, or re-enable a paused `catchup=true` schedule.
+
+This matches what most users expect ("turn on catchup ⇒ see the backfill"), but is a deliberate divergence — Airflow's equivalent behaviour is "the next DagRun after now is the earliest missed one, and subsequent loops fill in the rest over time".
+
+### Leader election via Payara, not advisory locks
+
+Airflow coordinates multiple schedulers with PostgreSQL advisory locks (`pg_try_advisory_xact_lock`). Hopsworks uses Payara's cluster primary election: the scheduler timer only fires on the primary node. Reconciliation happens on the first primary-owned tick after startup. Correctness is backed by a DB unique index on `(job_id, logical_date)`, so even during a leader failover window no duplicate runs are created.
+

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -20,7 +20,7 @@ Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](
 !!! note "Parallel executions"
     By default, at most one execution of a job runs at a time.
     If a fire time is reached while a previous execution is still running, the scheduler waits for the previous run to finish before starting the new one.
-    You can raise this cap with `max_active_runs` (see [Advanced scheduling](#advanced-scheduling)).
+    You can raise this cap with `max_active_runs` (see [Scheduling fields](#scheduling-fields)).
 
 ## Logical time and data intervals
 

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -9,23 +9,70 @@ description: Documentation on how to schedule a job on Hopsworks.
 Hopsworks clusters can run jobs on a schedule, allowing you to automate the execution.
 Whether you need to backfill your feature groups on a nightly basis or run a model training pipeline every week, the Hopsworks scheduler will help you automate these tasks.
 Each job can be configured to have a single schedule.
-For more advanced use cases, Hopsworks integrates with any DAG manager and directly with the open-source [Apache Airflow](https://airflow.apache.org/use-cases/), check out our [Airflow Guide](../airflow/airflow.md).
+For more advanced use cases, Hopsworks integrates with any DAG manager and directly with the open-source [Apache Airflow](https://airflow.apache.org/use-cases/); see our [Airflow Guide](../airflow/airflow.md).
 
-Schedules can be defined using the drop down menus in the UI or a Quartz [cron](https://en.wikipedia.org/wiki/Cron) expression.
+Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](https://en.wikipedia.org/wiki/Cron) expression.
 
 !!! note "Schedule frequency"
     The Hopsworks scheduler runs every minute.
     As such, the scheduling frequency should be of at least 1 minute.
 
 !!! note "Parallel executions"
-    If a job execution needs to be scheduled, the scheduler will first check that there are no active executions for that job.
-    If there is an execution running, the scheduler will postpone the execution until the running one is done.
+    By default, at most one execution of a job runs at a time.
+    If a fire time is reached while a previous execution is still running, the scheduler waits for the previous run to finish before starting the new one.
+    You can raise this cap with `max_active_runs` (see [Advanced scheduling](#advanced-scheduling)).
+
+## Logical time and data intervals
+
+When the scheduler fires a job, it attaches a **data interval** to the execution. The interval follows the same model as Apache Airflow:
+
+- `HOPS_LOGICAL_DATE` — start of the data interval. With a cron schedule, this is the *previous* cron fire; for the first run of a schedule it clamps to the schedule's start time.
+- `HOPS_END_TIME`     — end of the data interval = the current cron fire.
+- `HOPS_START_TIME`   — by default equal to `HOPS_LOGICAL_DATE`. It can be shifted using `start_time_offset_seconds` (see [Advanced scheduling](#advanced-scheduling)).
+
+These three values are injected into the job container as **environment variables** on every scheduled execution. In your program, read them like any other env var:
+
+=== "Python"
+    ```python
+    import os
+    from datetime import datetime
+
+    start = datetime.fromisoformat(os.environ["HOPS_START_TIME"])
+    end   = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
+    print(f"Processing rows in [{start}, {end})")
+    ```
+
+=== "PySpark"
+    ```python
+    import os
+    from pyspark.sql import functions as F
+
+    start = os.environ["HOPS_START_TIME"]
+    end   = os.environ["HOPS_END_TIME"]
+
+    df = spark.read.table("events").where(
+        (F.col("event_ts") >= F.lit(start)) &
+        (F.col("event_ts") <  F.lit(end))
+    )
+    ```
+
+### Why intervals and not just "now"?
+
+A scheduled run represents a *time slice of data to process*, not the wall-clock moment the container happened to start. Decoupling the two matters:
+
+- If the scheduler is down for six hours and an hourly job resumes, each catch-up run still sees the interval it was supposed to cover — not six copies of "now".
+- Backfills work naturally: replaying an interval produces the same output as the original run.
+- Downstream consumers can rely on the interval end being monotonic even when upstream is delayed.
+
+### Legacy `-start_time` argument
+
+For backwards compatibility the scheduler also appends `-start_time <logical date>` to the job arguments (or `-p start_time <logical date>` for Papermill notebooks). New code should prefer the `HOPS_*` environment variables — they're present on every job type and don't require parsing CLI args.
 
 ## UI
 
-### Scheduling Jobs
+### Scheduling a job
 
-You can define a schedule for a job during the creation of the job itself or after the job has been created from the job overview UI.
+You can define a schedule for a job during the creation of the job itself or after the job has been created, from the job overview UI.
 
 <p align="center">
   <figure>
@@ -34,18 +81,13 @@ You can define a schedule for a job during the creation of the job itself or aft
   </figure>
 </p>
 
-The *add schedule* prompt requires you to select a frequency either through the drop down menus or by using a cron expression.
-You can also provide a start time to specify from when the schedule should have effect.
-The start time can also be in the past.
-If that's the case, the scheduler will backfill the executions from the specified start time.
-As mentioned above, the execution backfilling will happen one execution at the time.
+The *add schedule* prompt requires you to select a frequency either through the drop-down menus or by using a cron expression.
+You can also provide a start time to specify when the schedule should take effect. The start time can be in the past.
+You can optionally provide an end time, in which case the scheduler stops firing after that point.
 
-You can optionally provide an end date time to specify until when the scheduling should continue.
-The end time can also be in the past.
+In the job overview you can see the current scheduling configuration, whether it is enabled, and when the next execution is planned for.
 
-In the job overview, you can see the current scheduling configuration, whether or not it is enabled and when the next execution is planned for.
-
-All times will be considered as UTC time.
+All times are in UTC.
 
 <p align="center">
   <figure>
@@ -54,25 +96,81 @@ All times will be considered as UTC time.
   </figure>
 </p>
 
-#### Job argument
+### Advanced scheduling
 
-When a job execution is triggered by the scheduler, a `-start_time` argument is added to the job arguments.
-The `-start_time` value will be the time of the scheduled execution in UTC in the ISO-8601 format (e.g.: `-start_time 2023-08-19T18:00:00Z`).
+The *Advanced scheduling* section on the schedule form exposes fields that shape catch-up behaviour, concurrency and the emitted time-window.
 
-The `-start_time` value passed as argument represents the time when the execution was scheduled, not when the execution was started.
-For example, if the scheduled execution time was in the past (e.g., in the case of backfilling), the `-start_time` passed to the execution is the time in the past, not the current time when the execution is running.
-Similarly, if the scheduler was not running for a period of time, when it comes back online, it will start the executions it missed to schedule while offline.
-Even in that case, the `-start_time` value will contain the time at which the execution was supposed to be started, not the current time.
+| Field | Default | Description |
+|---|---|---|
+| `catchup` | `false` | If `true`, on recovery after a scheduler outage the runs for every missed interval are created. If `false`, only the most recent missed interval is created. |
+| `max_active_runs` | `1` | Upper bound on concurrent executions for this job. |
+| `start_time_offset_seconds` | `0` | Shifts `HOPS_START_TIME` by this many seconds relative to the interval start. Negative values look further into the past. |
+| `end_time_offset_seconds` | `0` | Shifts `HOPS_END_TIME` by this many seconds relative to the interval end. |
+| `skip_to_date` | *unset* | When `catchup=true`, missed intervals strictly before this date are skipped during reconciliation. |
+| `max_catchup_runs` | *unset* | When `catchup=true`, caps how many missed intervals are replayed, keeping the most recent. |
 
-### Disable / Enable a schedule
+**Example — "process the previous day, not the previous hour"**
 
-You can decide to pause the scheduling of a job and avoid new executions to be started.
-You can later on re-enable the same scheduling configuration, and the scheduler will run the executions that were skipped while the schedule was disabled, if any, sequentially.
-In this way you will backfill the executions in between.
+An hourly job typically processes the last hour. To process "yesterday's data" every hour instead, shift both offsets back 24 hours:
 
-You can skip the backfilling of the executions by editing the scheduling configuration and bringing forward the schedule start time for the job.
+```
+start_time_offset_seconds = -86400
+end_time_offset_seconds   = -86400
+```
 
-### Delete a scheduling
+At 11:00 UTC the container sees `HOPS_START_TIME = 09:00 (previous day)` and `HOPS_END_TIME = 10:00 (previous day)`.
+
+**Example — `catchup=false` after a 6-hour outage**
+
+With an hourly schedule and `catchup=false`, if the scheduler is unreachable from 00:00 to 06:00, on recovery the scheduler creates one execution — the 06:00 interval — not six. This matches Airflow's `catchup_by_default=False` semantics.
+
+**Example — bounded replay**
+
+With `catchup=true`, `max_catchup_runs=24` and a 1-week outage on an hourly schedule, only the most recent 24 missed intervals are replayed; older ones are dropped.
+
+### Disable / enable a schedule
+
+You can pause a schedule to prevent further executions. When re-enabled, the next fire uses the current time as the starting point (pause is not the same as an outage — paused time is not considered "missed").
+
+Use `skip_to_date` (advanced) if you want a paused-and-re-enabled schedule with `catchup=true` to skip over the pause window.
+
+### Delete a schedule
 
 You can remove the schedule for a job using the UI and by clicking on the trash icon on the schedule section of the job overview.
-If you re-schedule a job after having deleted the previous schedule, even with the same options, it will not take into account previous scheduled executions.
+If you re-schedule a job after having deleted the previous schedule, even with the same options, previous scheduled executions are not considered.
+
+## Python API
+
+```python
+from datetime import datetime, timezone
+import hopsworks
+
+project = hopsworks.login()
+job = project.get_job_api().get_job("my_feature_pipeline")
+
+# Hourly, defaults: HOPS_START_TIME = previous fire, HOPS_END_TIME = current fire.
+job.schedule(
+    cron_expression="0 0 * ? * * *",
+    start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+)
+
+# Hourly, shifted window — "process the previous hour one hour later".
+job.schedule(
+    cron_expression="0 0 * ? * * *",
+    start_time_offset_seconds=-3600,
+    end_time_offset_seconds=-3600,
+    catchup=True,
+    max_active_runs=2,
+    max_catchup_runs=24,
+)
+
+# Inspect
+schedule = job.job_schedule
+print(schedule.cron_expression, schedule.catchup, schedule.max_active_runs)
+print(schedule.next_execution_date_time)
+
+# Remove
+job.unschedule()
+```
+
+See also [Batch feature pipelines](./batch_feature_pipeline.md) for one-shot backfill runs and the `Job.run(start_time=..., end_time=...)` API.

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -41,6 +41,7 @@ These three values are injected into the job container as **environment variable
     import os
     from datetime import datetime
 
+
     start = datetime.fromisoformat(os.environ["HOPS_START_TIME"])
     end = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
     print(f"Processing rows in [{start}, {end})")
@@ -52,6 +53,7 @@ These three values are injected into the job container as **environment variable
 
     from pyspark.sql import SparkSession
     from pyspark.sql import functions as F
+
 
     spark = SparkSession.builder.getOrCreate()
 

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -9,7 +9,7 @@ description: Documentation on how to schedule a job on Hopsworks.
 Hopsworks clusters can run jobs on a schedule, allowing you to automate the execution.
 Whether you need to backfill your feature groups on a nightly basis or run a model training pipeline every week, the Hopsworks scheduler will help you automate these tasks.
 Each job can be configured to have a single schedule.
-For more advanced use cases, Hopsworks integrates with any DAG manager and directly with the open-source [Apache Airflow](https://airflow.apache.org/use-cases/); see our [Airflow Guide](../airflow/airflow.md).
+For more advanced use cases, Hopsworks integrates with any DAG manager and directly with the open-source [Apache Airflow](https://airflow.apache.org/use-cases/); see our [Airflow Guide][orchestrate-jobs-using-apache-airflow].
 
 Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](https://en.wikipedia.org/wiki/Cron) expression.
 
@@ -27,8 +27,8 @@ Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](
 When the scheduler fires a job, it attaches a **data window** to the execution, expressed through three environment variables:
 
 - `HOPS_START_TIME` — start of the data window. Two modes:
-    - **Last execution time** *(default — `start_time_offset_seconds = null`)* — the previous cron fire. Adapts to the schedule's cadence, so the window is always "everything since the previous run".
-    - **Before last execution (hh:mm)** — `previous_fire − (hh*3600 + mm*60)` seconds. Stored as a positive integer; the backend subtracts.
+  - **Last execution time** *(default — `start_time_offset_seconds = null`)* — the previous cron fire. Adapts to the schedule's cadence, so the window is always "everything since the previous run".
+  - **Before last execution (hh:mm)** — `previous_fire − (hh*3600 + mm*60)` seconds. Stored as a positive integer; the backend subtracts.
 - `HOPS_END_TIME` — end of the data window. **Always `HOPS_START_TIME + cron interval`** so consecutive scheduled runs tile the timeline with no gaps between them. `end_time_offset_seconds` is kept on the DTO for backward compatibility but is ignored.
 - `HOPS_LOGICAL_DATE` — the scheduler's stable identifier for this interval (Airflow-style *start of interval* = previous cron fire). Used for dedup and retries.
 
@@ -42,21 +42,24 @@ These three values are injected into the job container as **environment variable
     from datetime import datetime
 
     start = datetime.fromisoformat(os.environ["HOPS_START_TIME"])
-    end   = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
+    end = datetime.fromisoformat(os.environ["HOPS_END_TIME"])
     print(f"Processing rows in [{start}, {end})")
     ```
 
 === "PySpark"
     ```python
     import os
+
+    from pyspark.sql import SparkSession
     from pyspark.sql import functions as F
 
+    spark = SparkSession.builder.getOrCreate()
+
     start = os.environ["HOPS_START_TIME"]
-    end   = os.environ["HOPS_END_TIME"]
+    end = os.environ["HOPS_END_TIME"]
 
     df = spark.read.table("events").where(
-        (F.col("event_ts") >= F.lit(start)) &
-        (F.col("event_ts") <  F.lit(end))
+        (F.col("event_ts") >= F.lit(start)) & (F.col("event_ts") < F.lit(end))
     )
     ```
 
@@ -105,7 +108,7 @@ All times are in UTC.
 The Schedule form exposes these fields for controlling the data window, concurrency and catch-up behaviour:
 
 | Field | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `max_active_runs` | `1` | Upper bound on concurrent executions for this job. |
 | `start_time_offset_seconds` | `null` *(last execution time)* | `null` → `HOPS_START_TIME = previous cron fire`. Positive integer → `HOPS_START_TIME = previous fire − seconds` (shifts the window earlier). Must be ≥ 0. |
 | `end_time_offset_seconds` | *legacy; ignored* | Kept on the DTO for backward compatibility. The backend always sets `HOPS_END_TIME = HOPS_START_TIME + cron interval` — consecutive runs tile the timeline with no gaps. |
@@ -113,22 +116,22 @@ The Schedule form exposes these fields for controlling the data window, concurre
 | `skip_to_date` | *unset* | When `catchup=true`, missed intervals strictly before this date are skipped during reconciliation. |
 | `max_catchup_runs` | *unset* | When `catchup=true`, caps how many missed intervals are replayed, keeping the most recent. |
 
-**Example — "process the previous 25 hours, not the previous hour"**
+#### Example — "process the previous 25 hours, not the previous hour"
 
 Defaults give you the natural cron interval (`[previous fire, current fire)`). To process a 25-hour trailing window every hour (e.g. to include a little overlap for late-arriving data), shift `start` 24 hours earlier — the end stays at the current fire because it's `start + cron interval = start + 1 h`:
 
-```
+```text
 start_time_offset_seconds = 25 * 3600   # HOPS_START_TIME = previous fire − 25 h
 # end_time_offset_seconds is ignored; HOPS_END_TIME = HOPS_START_TIME + 1 h
 ```
 
 At 11:00 UTC on an hourly schedule the container sees `HOPS_START_TIME = 09:00 (previous day)` and `HOPS_END_TIME = 10:00 (previous day)`.
 
-**Example — `catchup=false` after a 6-hour outage**
+#### Example — `catchup=false` after a 6-hour outage
 
 With an hourly schedule and `catchup=false`, if the scheduler is unreachable from 00:00 to 06:00, on recovery the scheduler creates one execution — the 06:00 interval — not six. This matches Airflow's `catchup_by_default=False` semantics.
 
-**Example — bounded replay**
+#### Example — bounded replay
 
 With `catchup=true`, `max_catchup_runs=24` and a 1-week outage on an hourly schedule, only the most recent 24 missed intervals are replayed; older ones are dropped.
 
@@ -146,8 +149,10 @@ If you re-schedule a job after having deleted the previous schedule, even with t
 ## Python API
 
 ```python
-from datetime import datetime, timezone
+from datetime import UTC, datetime
+
 import hopsworks
+
 
 project = hopsworks.login()
 job = project.get_job_api().get_job("my_feature_pipeline")
@@ -157,7 +162,7 @@ job = project.get_job_api().get_job("my_feature_pipeline")
 # daily gives the last day, etc.
 job.schedule(
     cron_expression="0 0 * ? * * *",
-    start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    start_time=datetime(2026, 1, 1, tzinfo=UTC),
 )
 
 # Shift the window 1 hour earlier so each hourly run sees the previous-to-previous
@@ -165,7 +170,7 @@ job.schedule(
 # window remains 1 hour wide — only the anchor moves.
 job.schedule(
     cron_expression="0 0 * ? * * *",
-    start_time_offset_seconds=3600,   # previous fire − 1 h
+    start_time_offset_seconds=3600,  # previous fire − 1 h
     catchup=True,
     max_active_runs=2,
     max_catchup_runs=24,
@@ -180,7 +185,7 @@ print(schedule.next_execution_date_time)
 job.unschedule()
 ```
 
-See also [Batch feature pipelines](./batch_feature_pipeline.md) for one-shot backfill runs and the `Job.run(start_time=..., end_time=...)` API.
+See also [Batch feature pipelines][batch-feature-pipelines] for one-shot backfill runs and the `Job.run(start_time=..., end_time=...)` API.
 
 ## Differences from Apache Airflow
 
@@ -217,4 +222,3 @@ This matches what most users expect ("turn on catchup ⇒ see the backfill"), bu
 ### Leader election via Payara, not advisory locks
 
 Airflow coordinates multiple schedulers with PostgreSQL advisory locks (`pg_try_advisory_xact_lock`). Hopsworks uses Payara's cluster primary election: the scheduler timer only fires on the primary node. Reconciliation happens on the first primary-owned tick after startup. Correctness is backed at the application layer — `executeWithCron` seeds `startingActive = countActiveByJob(...)` once per tick and tracks an additive `firedThisTick` counter, which is monotonic and independent of RonDB COUNT read-after-write lag. This replaces an earlier `(job_id, logical_date)` unique index that was too strict — it blocked legitimate retry / manual-rerun / re-backfill flows that share a logical_date.
-

--- a/docs/user_guides/projects/jobs/schedule_job.md
+++ b/docs/user_guides/projects/jobs/schedule_job.md
@@ -24,11 +24,13 @@ Schedules can be defined using the drop-down menus in the UI or a Quartz [cron](
 
 ## Logical time and data intervals
 
-When the scheduler fires a job, it attaches a **data interval** to the execution. The interval follows the same model as Apache Airflow:
+When the scheduler fires a job, it attaches a **data window** to the execution, expressed through three environment variables:
 
-- `HOPS_LOGICAL_DATE` — start of the data interval. With a cron schedule, this is the *previous* cron fire; for the first run of a schedule it clamps to the schedule's start time.
-- `HOPS_END_TIME`     — end of the data interval = the current cron fire.
-- `HOPS_START_TIME`   — by default equal to `HOPS_LOGICAL_DATE`. It can be shifted using `start_time_offset_seconds` (see [Advanced scheduling](#advanced-scheduling)).
+- `HOPS_START_TIME` — start of the data window. Computed as `cron_fire_time + start_time_offset_seconds`. Default offset is **-3600** (one hour before the fire).
+- `HOPS_END_TIME`   — end of the data window. Computed as `cron_fire_time + end_time_offset_seconds`. Default offset is **0** (at the fire).
+- `HOPS_LOGICAL_DATE` — the scheduler's dedup key for this interval (Airflow-style *start of interval* = previous cron fire). Useful as a stable identifier for the run.
+
+With the defaults on an hourly schedule firing at 10:00, the window is `[09:00, 10:00)` — the last hour of data. Change the offsets (see below) to shape a different window.
 
 These three values are injected into the job container as **environment variables** on every scheduled execution. In your program, read them like any other env var:
 
@@ -96,29 +98,33 @@ All times are in UTC.
   </figure>
 </p>
 
-### Advanced scheduling
+### Scheduling fields
 
-The *Advanced scheduling* section on the schedule form exposes fields that shape catch-up behaviour, concurrency and the emitted time-window.
+The Schedule form exposes these fields for controlling the data window, concurrency and catch-up behaviour:
 
 | Field | Default | Description |
 |---|---|---|
-| `catchup` | `false` | If `true`, on recovery after a scheduler outage the runs for every missed interval are created. If `false`, only the most recent missed interval is created. |
 | `max_active_runs` | `1` | Upper bound on concurrent executions for this job. |
-| `start_time_offset_seconds` | `0` | Shifts `HOPS_START_TIME` by this many seconds relative to the interval start. Negative values look further into the past. |
-| `end_time_offset_seconds` | `0` | Shifts `HOPS_END_TIME` by this many seconds relative to the interval end. |
+| `start_time_offset_seconds` | `-3600` | Seconds added to the cron fire time to produce `HOPS_START_TIME`. Negative values look backwards; positive values look forward. |
+| `end_time_offset_seconds` | `0` | Seconds added to the cron fire time to produce `HOPS_END_TIME`. |
+| `catchup` | `false` | If `true`, on recovery after a scheduler outage the runs for every missed interval are created. If `false`, only the most recent missed interval is created. |
 | `skip_to_date` | *unset* | When `catchup=true`, missed intervals strictly before this date are skipped during reconciliation. |
 | `max_catchup_runs` | *unset* | When `catchup=true`, caps how many missed intervals are replayed, keeping the most recent. |
 
 **Example — "process the previous day, not the previous hour"**
 
-An hourly job typically processes the last hour. To process "yesterday's data" every hour instead, shift both offsets back 24 hours:
+Defaults give you the last hour (`[fire-1h, fire)`). To process yesterday's data every hour instead, shift both offsets back 24 hours:
 
 ```
-start_time_offset_seconds = -86400
-end_time_offset_seconds   = -86400
+start_time_offset_seconds = -25 * 3600   # fire - 25 h
+end_time_offset_seconds   = -24 * 3600   # fire - 24 h
 ```
 
-At 11:00 UTC the container sees `HOPS_START_TIME = 09:00 (previous day)` and `HOPS_END_TIME = 10:00 (previous day)`.
+At 11:00 UTC the container sees `HOPS_START_TIME = 10:00 (previous day)` and `HOPS_END_TIME = 11:00 (previous day)`.
+
+**Example — window ending in the future**
+
+Positive offsets look forward. `start_time_offset_seconds = 0`, `end_time_offset_seconds = 3600` produces a window from the fire time to one hour after — useful when the pipeline reads forecasts rather than history.
 
 **Example — `catchup=false` after a 6-hour outage**
 
@@ -148,17 +154,17 @@ import hopsworks
 project = hopsworks.login()
 job = project.get_job_api().get_job("my_feature_pipeline")
 
-# Hourly, defaults: HOPS_START_TIME = previous fire, HOPS_END_TIME = current fire.
+# Hourly. Defaults yield HOPS_START_TIME = fire - 1 h, HOPS_END_TIME = fire (the last hour).
 job.schedule(
     cron_expression="0 0 * ? * * *",
     start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
 )
 
-# Hourly, shifted window — "process the previous hour one hour later".
+# Hourly, 2-hour window ending at the cron fire:
 job.schedule(
     cron_expression="0 0 * ? * * *",
-    start_time_offset_seconds=-3600,
-    end_time_offset_seconds=-3600,
+    start_time_offset_seconds=-2 * 3600,
+    end_time_offset_seconds=0,
     catchup=True,
     max_active_runs=2,
     max_catchup_runs=24,

--- a/docs/user_guides/projects/jobs/spark_job.md
+++ b/docs/user_guides/projects/jobs/spark_job.md
@@ -271,6 +271,32 @@ This configuration is mainly useful when you need to add additional configuratio
 
 When reading data in your Spark job it is recommended to use the Spark read API as previously demonstrated, since this reads from the filesystem directly, whereas `Additional files` configuration options will download the files in its entirety and is not a scalable option.
 
+## Environment variables
+
+User-defined environment variables can be attached to a Spark job under the
+*Environment variables* panel of the advanced configuration. Each entry is a
+`KEY=VALUE` pair that is set on the Spark driver container for every execution
+of the job.
+
+```python
+import os
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.getOrCreate()
+bucket = os.environ["MY_S3_BUCKET"]
+df = spark.read.parquet(f"s3a://{bucket}/events/")
+```
+
+Scheduled and backfill runs also receive `HOPS_LOGICAL_DATE`, `HOPS_START_TIME`
+and `HOPS_END_TIME` describing the data interval the run should process — see
+[Scheduling](./schedule_job.md#logical-time-and-data-intervals) and
+[Batch feature pipelines](./batch_feature_pipeline.md).
+
+!!! warning "Reserved names"
+    Names starting with `HOPS_` are reserved by the scheduler. Setting them in
+    the *Environment variables* panel overrides the scheduler value for every
+    execution — the UI shows a warning callout when you do this.
+
 ## API Reference
 
 [`Job`][hopsworks_common.job.Job]

--- a/docs/user_guides/projects/jobs/spark_job.md
+++ b/docs/user_guides/projects/jobs/spark_job.md
@@ -201,6 +201,7 @@ spark_config["appPath"] = uploaded_file_path
 spark_config["mainClass"] = "org.apache.spark.examples.SparkPi"
 
 job = jobs_api.create_job("pyspark_job", spark_config)
+
 ```
 
 ### Step 3: Execute the job
@@ -217,6 +218,7 @@ print(f_out.read())
 
 f_err = open(err, "r")
 print(f_err.read())
+
 ```
 
 ## Configuration
@@ -280,17 +282,20 @@ of the job.
 
 ```python
 import os
+
 from pyspark.sql import SparkSession
+
 
 spark = SparkSession.builder.getOrCreate()
 bucket = os.environ["MY_S3_BUCKET"]
 df = spark.read.parquet(f"s3a://{bucket}/events/")
+df.printSchema()
 ```
 
 Scheduled and backfill runs also receive `HOPS_LOGICAL_DATE`, `HOPS_START_TIME`
 and `HOPS_END_TIME` describing the data interval the run should process — see
-[Scheduling](./schedule_job.md#logical-time-and-data-intervals) and
-[Batch feature pipelines](./batch_feature_pipeline.md).
+[Scheduling][logical-time-and-data-intervals] and
+[Batch feature pipelines][batch-feature-pipelines].
 
 !!! warning "Reserved names"
     Names starting with `HOPS_` are reserved by the scheduler. Setting them in

--- a/docs/user_guides/projects/jobs/spark_job.md
+++ b/docs/user_guides/projects/jobs/spark_job.md
@@ -201,7 +201,6 @@ spark_config["appPath"] = uploaded_file_path
 spark_config["mainClass"] = "org.apache.spark.examples.SparkPi"
 
 job = jobs_api.create_job("pyspark_job", spark_config)
-
 ```
 
 ### Step 3: Execute the job
@@ -218,7 +217,6 @@ print(f_out.read())
 
 f_err = open(err, "r")
 print(f_err.read())
-
 ```
 
 ## Configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
               - Run Spark Job: user_guides/projects/jobs/spark_job.md
               - Run Ray Job: user_guides/projects/jobs/ray_job.md
               - Scheduling: user_guides/projects/jobs/schedule_job.md
+              - Batch Feature Pipelines: user_guides/projects/jobs/batch_feature_pipeline.md
           - Kubernetes Scheduling:
               - Base: user_guides/projects/scheduling/kube_scheduler.md
               - Kueue: user_guides/projects/scheduling/kueue_details.md


### PR DESCRIPTION
Docs for the logical-time scheduling feature. Companion PRs:
- Backend: [logicalclocks/hopsworks-ee#2811](https://github.com/logicalclocks/hopsworks-ee/pull/2811)
- Frontend: [logicalclocks/hopsworks-front#1814](https://github.com/logicalclocks/hopsworks-front/pull/1814)
- Python SDK: [logicalclocks/hopsworks-api#917](https://github.com/logicalclocks/hopsworks-api/pull/917)

## Summary

- **Rewrite `schedule_job.md`**: the old ``-start_time`` argument section is replaced with the new `HOPS_LOGICAL_DATE` / `HOPS_START_TIME` / `HOPS_END_TIME` environment variables. Adds an Advanced scheduling reference table (`catchup`, `max_active_runs`, `start/end_time_offset_seconds`, `skip_to_date`, `max_catchup_runs`) with worked examples (shifted window, `catchup=false` after outage, bounded replay) and a Python SDK snippet.
- **New `batch_feature_pipeline.md`**: covers the two operating modes:
  - **Incremental** — recurring schedule with offsets; scheduler injects fresh `HOPS_*` per run.
  - **Backfill** — one-shot run with explicit start/end, via the UI's "Run with time window" dialog or `job.run(start_time=..., end_time=...)`.
  Plus the env-var precedence rules (per-run > job-config > scheduler > Hopsworks defaults).
- **`python_job.md` / `spark_job.md`**: new *Environment variables* section linking to the scheduler docs and noting the reserved `HOPS_*` prefix.
- **`mkdocs.yml`**: adds *Batch Feature Pipelines* under the Jobs nav.

Screenshots for the Advanced Scheduling form and the Run-with-time-window dialog will be added in a follow-up commit.

## Test plan

- [ ] `mkdocs build` passes without broken links or nav warnings.
- [ ] Internal links (`schedule_job.md#advanced-scheduling`, `schedule_job.md#logical-time-and-data-intervals`, `batch_feature_pipeline.md`) all resolve on the rendered site.
- [ ] API-reference blocks for `Job` / `JobSchedule` / `Execution` still render after the Python SDK PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)