### PR TITLE
[FSTORE-2017] Add support for Unity Catalog Data Source

### DIFF
--- a/docs/concepts/dev/outside.md
+++ b/docs/concepts/dev/outside.md
@@ -3,6 +3,6 @@ Hopsworks also running SQL queries to compute features in external data warehous
 The Feature Store can also be queried with SQL.
 
 There is REST API for Hopsworks that can be used with a valid API key, generated in Hopsworks.
-However, it is often easier to develop your programs against SDKs available in Python and Java/Scala for HSFS, in Python for HSML, and in Python for the Hopsworks API.
+However, it is often easier to develop your programs against SDKs available in Python and Java/Scala for Hopsworks, in Python for HSML, and in Python for the Hopsworks API.
 
 <img src="../../../assets/images/concepts/dev/dev-outside.svg">

--- a/docs/concepts/fs/feature_group/external_fg.md
+++ b/docs/concepts/fs/feature_group/external_fg.md
@@ -4,6 +4,6 @@ An external feature group doesn't allow for offline data ingestion or modificati
 You can also perform SQL operations, including projections, aggregations, and so on.
 The SQL query is executed on-demand when HSFS retrieves data from the external Feature Group, for example, when creating training data using features in the external table.
 
-In the image below, we can see that HSFS currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, S3, ADLS, GCS, SQL, and Kafka
+In the image below, we can see that HSFS currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, Databricks Unity Catalog (Delta tables), S3, ADLS, GCS, SQL, and Kafka
 
 <img src="../../../../assets/images/concepts/fs/fg-connector-api.svg">

--- a/docs/concepts/fs/feature_group/external_fg.md
+++ b/docs/concepts/fs/feature_group/external_fg.md
@@ -1,9 +1,9 @@
 External feature groups are offline feature groups where their data is stored in an external table.
-An external table requires a data source, defined with the Connector API (or more typically in the user interface), to enable HSFS to retrieve data from the external table.
+An external table requires a data source, defined with the Connector API (or more typically in the user interface), to enable Hopsworks to retrieve data from the external table.
 An external feature group doesn't allow for offline data ingestion or modification; instead, it includes a user-defined SQL string for retrieving data.
 You can also perform SQL operations, including projections, aggregations, and so on.
-The SQL query is executed on-demand when HSFS retrieves data from the external Feature Group, for example, when creating training data using features in the external table.
+The SQL query is executed on-demand when Hopsworks retrieves data from the external Feature Group, for example, when creating training data using features in the external table.
 
-In the image below, we can see that HSFS currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, Databricks Unity Catalog (Delta tables on Databricks on AWS only), S3, ADLS, GCS, SQL, and Kafka
+In the image below, we can see that Hopsworks currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, Databricks Unity Catalog (Delta tables on Databricks on AWS only), S3, ADLS, GCS, SQL, and Kafka
 
 <img src="../../../../assets/images/concepts/fs/fg-connector-api.svg">

--- a/docs/concepts/fs/feature_group/external_fg.md
+++ b/docs/concepts/fs/feature_group/external_fg.md
@@ -4,6 +4,6 @@ An external feature group doesn't allow for offline data ingestion or modificati
 You can also perform SQL operations, including projections, aggregations, and so on.
 The SQL query is executed on-demand when HSFS retrieves data from the external Feature Group, for example, when creating training data using features in the external table.
 
-In the image below, we can see that HSFS currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, Databricks Unity Catalog (Delta tables), S3, ADLS, GCS, SQL, and Kafka
+In the image below, we can see that HSFS currently supports a large number of data sources, including any JDBC-enabled source, Snowflake, Data Lake, Redshift, BigQuery, Databricks Unity Catalog (Delta tables on Databricks on AWS only), S3, ADLS, GCS, SQL, and Kafka
 
 <img src="../../../../assets/images/concepts/fs/fg-connector-api.svg">

--- a/docs/concepts/fs/feature_group/feature_monitoring.md
+++ b/docs/concepts/fs/feature_group/feature_monitoring.md
@@ -1,6 +1,6 @@
 Feature Monitoring complements data validation capabilities by allowing you to monitor your feature data after it has been ingested into the Feature Store.
 
-HSFS supports monitoring features on your Feature Group by:
+Hopsworks supports monitoring features on your Feature Group by:
 
 - transparently **computing statistics** on the whole or a subset of feature data defined by a detection window.
 - **comparing statistics** against a reference window of feature data, and **configuring thresholds** to identify anomalous data.
@@ -8,7 +8,7 @@ HSFS supports monitoring features on your Feature Group by:
 
 ## Scheduled Statistics
 
-After creating a Feature Group in HSFS, you can setup statistics monitoring to compute statistics over one or more features on a scheduled basis.
+After creating a Feature Group in Hopsworks, you can setup statistics monitoring to compute statistics over one or more features on a scheduled basis.
 Statistics are computed on the whole or a subset of feature data (i.e., detection window) already inserted into the Feature Group.
 
 ## Statistics Comparison

--- a/docs/concepts/fs/feature_group/feature_pipelines.md
+++ b/docs/concepts/fs/feature_group/feature_pipelines.md
@@ -1,5 +1,5 @@
 A feature pipeline is a program that orchestrates the execution of a dataflow graph of data validation, aggregation, dimensionality reduction, transformation, and other feature engineering steps on input data to create and/or update feature data.
-With HSFS, you can write feature pipelines in different languages as shown in the figure below.
+With Hopsworks, you can write feature pipelines in different languages as shown in the figure below.
 
 <img src="../../../../assets/images/concepts/fs/feature-pipelines.svg">
 
@@ -13,7 +13,7 @@ SparkSQL, in contrast, can be used over tables that originate in different  data
 
 In order to be able to train and serve models that you can rely on, you need clean, high quality features.
 Data validation operations include removing bad data, removing or imputing missing values, and identifying problems such as feature shift.
-HSFS supports Great Expectations to specify data validation rules that are executed in the client before features are written to the Feature Store.
+Hopsworks supports Great Expectations to specify data validation rules that are executed in the client before features are written to the Feature Store.
 The validation results are collected and shown in Hopsworks.
 
 ### Aggregations

--- a/docs/concepts/fs/feature_group/fg_statistics.md
+++ b/docs/concepts/fs/feature_group/fg_statistics.md
@@ -1,4 +1,4 @@
-HSFS supports monitoring, validation, and alerting for features:
+Hopsworks supports monitoring, validation, and alerting for features:
 
 - transparently compute statistics over features on writing to a feature group;
 - validation of data written to feature groups using Great Expectations
@@ -6,7 +6,7 @@ HSFS supports monitoring, validation, and alerting for features:
 
 ### Statistics
 
-When you create a Feature Group in HSFS, you can configure it to compute statistics over the features inserted into the Feature Group by setting the `statistics_config` dict parameter, see [Feature Group Statistics](../../../user_guides/fs/feature_group/statistics.md) for details.
+When you create a Feature Group in Hopsworks, you can configure it to compute statistics over the features inserted into the Feature Group by setting the `statistics_config` dict parameter, see [Feature Group Statistics](../../../user_guides/fs/feature_group/statistics.md) for details.
 Every time you write to the Feature Group, new statistics will be computed over all of the data in the Feature Group.
 
 ### Data Validation
@@ -18,6 +18,6 @@ When you write to a feature group, the expectations are executed, then you can d
 
 ### Alerting
 
-HSFS also supports alerts, that can be triggered when there are problems in your feature pipelines, for example, when a write fails due to an error or a failed expectation.
+Hopsworks also supports alerts, that can be triggered when there are problems in your feature pipelines, for example, when a write fails due to an error or a failed expectation.
 You can send alerts to different alerting endpoints, such as email or Slack, that can be configured in the Hopsworks UI.
 For example, you can send a slack message if features being written to a feature group are missing some input data.

--- a/docs/concepts/fs/feature_view/feature_monitoring.md
+++ b/docs/concepts/fs/feature_view/feature_monitoring.md
@@ -1,6 +1,6 @@
 Feature Monitoring complements data validation capabilities by allowing you to monitor your feature data once they have been ingested into the Feature Store.
 
-HSFS supports monitoring features on your Feature View by:
+Hopsworks supports monitoring features on your Feature View by:
 
 - transparently **computing statistics** on the whole or a subset of feature data defined by a detection window.
 - **comparing statistics** against a reference window of feature data (e.g., training dataset), and **configuring thresholds** to identify anomalous data.
@@ -8,7 +8,7 @@ HSFS supports monitoring features on your Feature View by:
 
 ## Scheduled Statistics
 
-After creating a Feature View in HSFS, you can setup statistics monitoring to compute statistics over one or more features on a scheduled basis.
+After creating a Feature View in Hopsworks, you can setup statistics monitoring to compute statistics over one or more features on a scheduled basis.
 Statistics are computed on the whole or a subset of feature data (i.e., detection window) using the Feature View query.
 
 ## Statistics Comparison

--- a/docs/concepts/fs/feature_view/offline_api.md
+++ b/docs/concepts/fs/feature_view/offline_api.md
@@ -24,11 +24,11 @@ In this case, the application should know that predictions for this customer sho
 When you create training data from features in different feature groups, it is possible that the feature groups are updated at different cadences.
 For example, maybe one feature group is updated hourly, while another feature group is updated daily.
 It is very complex to write code that joins features together from such feature groups and ensures there is no data leakage in the resultant training data.
-HSFS hides this complexity by performing the point-in-time JOIN transparently, similar to the illustration below:
+Hopsworks hides this complexity by performing the point-in-time JOIN transparently, similar to the illustration below:
 
 <img src="../../../../assets/images/concepts/fs/feature-view-training-data.svg">
 
-HSFS uses the event_time columns on both feature groups to determine the most recent (but not newer) feature values that are joined together with the feature values from the feature group containing the label.
+Hopsworks uses the event_time columns on both feature groups to determine the most recent (but not newer) feature values that are joined together with the feature values from the feature group containing the label.
 That is, the features in the feature group containing the label are the observation times for the features in the resulting training data, and we want feature values from the other feature groups that have the most recent timestamps, but not newer than the timestamp in the label-containing feature group.
 
 #### Spine Groups
@@ -44,8 +44,8 @@ This is just one example where spines are helpful.
 
 ### Splitting Training Data
 
-You can create random train/validation/test splits of your training data using the HSFS API.
-You can also time-based splits with the HSFS API.
+You can create random train/validation/test splits of your training data using the Hopsworks API.
+You can also time-based splits with the Hopsworks API.
 
 ### Evaluation Sets
 

--- a/docs/concepts/fs/feature_view/online_api.md
+++ b/docs/concepts/fs/feature_view/online_api.md
@@ -10,6 +10,6 @@ A feature vector is a row of features (without the primary key(s) and event time
 
 It may be the case that for any given feature vector, not all features will come pre-engineered from the feature store.
 Some features will be provided by the client (or at least the raw data to compute the feature will come from the client).
-We call these 'passed' features and, similar to precomputed features from the feature store, they can also be transformed by the HSFS client in the method:
+We call these 'passed' features and, similar to precomputed features from the feature store, they can also be transformed by the Hopsworks client in the method:
 
 - feature_view.get_feature_vector(entry, passed_features={...})

--- a/docs/concepts/fs/feature_view/statistics.md
+++ b/docs/concepts/fs/feature_view/statistics.md
@@ -1,5 +1,5 @@
 The feature view does not contain any statistics, as it is simply an interface consisting of a number of features and any transformation functions applied to those features.
 
-However, training data can have descriptive statistics over it computed by HSFS.
+However, training data can have descriptive statistics over it computed by Hopsworks.
 Descriptive statistics for training data is important for model monitoring, as it can enable model monitoring.
 If you compute the same descriptive statistics over windows of input features to models, you can help determine when there is a significant change in the distribution of an input feature, so-called feature shift.

--- a/docs/concepts/fs/feature_view/training_inference_pipelines.md
+++ b/docs/concepts/fs/feature_view/training_inference_pipelines.md
@@ -15,7 +15,7 @@ In the image below, you can see that transformations happen after the Feature St
 <img src="../../../../assets/images/concepts/fs/no-training-serving-skew.svg">
 
 There are 3 main approaches to prevent training/serving skew that we support in Hopsworks.
-These are (1) perform transformations in models, (2) perform transformations in pipelines (sklearn, TF, PyTorch) and use the model registry to save the transformation pipeline so that the same transformation is used in your inference pipeline, and (3) use HSFS transformations, defined as UDFs in Python.
+These are (1) perform transformations in models, (2) perform transformations in pipelines (sklearn, TF, PyTorch) and use the model registry to save the transformation pipeline so that the same transformation is used in your inference pipeline, and (3) use Hopsworks transformations, defined as UDFs in Python.
 
 ### Transformations as Pre-Processing Layers in Models
 
@@ -30,11 +30,11 @@ You have to save your transformation pipeline (serialize the object or the param
 This means you should version the transformations.
 In Hopsworks, you can store the transformations with your versioned models in the Model Registry, helping you to ensure the same transformation pipeline is applied to both training/serving for the same model version.
 
-### Transformations as Python UDFs in HSFS
+### Transformations as Python UDFs in Hopsworks
 
 Hopsworks feature store also supports consistent transformation functions by enabling a Python UDF, that implements a transformation, to be attached a to feature in a feature view.
-When training data is created with a feature view or when a feature vector is retrieved from a feature view, HSFS ensures that any transformation functions defined over any features will be applied before returning feature values.
-You can use built-in transformation objects in HSFS or write your own custom transformation functions as Python UDFs.
+When training data is created with a feature view or when a feature vector is retrieved from a feature view, Hopsworks ensures that any transformation functions defined over any features will be applied before returning feature values.
+You can use built-in transformation objects in Hopsworks or write your own custom transformation functions as Python UDFs.
 The benefit of this approach is that transformations are applied consistently when creating training data and when retrieving feature data from the online feature store.
 Transformations no longer need to be included in either your training pipeline or inference pipeline, as they are applied transparently when creating training data and retrieving feature vectors.
 Hopsworks uses Spark to create training data as files, and any transformation functions for features are executed as Python UDFs in Spark - enabling transformation functions to be applied on large volumes of data and removing potentially CPU-intensive transformations from training pipelines.

--- a/docs/concepts/fs/index.md
+++ b/docs/concepts/fs/index.md
@@ -4,14 +4,14 @@
 ## What is Hopsworks Feature Store?
 
 Hopsworks and its Feature Store are an open source data-intensive AI platform used for the development and operation of machine learning models at scale.
-The Hopsworks Feature Store provides the HSFS API to enable clients to write features to feature groups in the feature store, and to read features from feature views - either through a low latency Online API to retrieve pre-computed features for operational models or through a high throughput, latency insensitive Offline API, used to create training data and to retrieve batch data for scoring.
+The Hopsworks Feature Store provides the Hopsworks API to enable clients to write features to feature groups in the feature store, and to read features from feature views - either through a low latency Online API to retrieve pre-computed features for operational models or through a high throughput, latency insensitive Offline API, used to create training data and to retrieve batch data for scoring.
 
 <img src="../../assets/images/concepts/fs/architecture.svg">
 
-## HSFS API
+## Hopsworks API
 
-The HSFS (Hopsworks Feature Store) API is how you, as a developer, will use the feature store.
-The HSFS API helps simplify some of the problems that feature stores address including:
+The Hopsworks API is how you, as a developer, will use the feature store.
+The Hopsworks API helps simplify some of the problems that feature stores address including:
 
 - consistent features for training and serving
 - centralized, secure access to features

--- a/docs/concepts/hopsworks.md
+++ b/docs/concepts/hopsworks.md
@@ -9,7 +9,7 @@ Hopsworks is a **modular** MLOps platform with:
 
 ## Standalone Feature Store
 
-Hopsworks was the first open-source and first enterprise feature store for ML.  You can use Hopsworks as a standalone feature store with the HSFS API.
+Hopsworks was the first open-source and first enterprise feature store for ML.  You can use Hopsworks as a standalone feature store with the Hopsworks API.
 
 ## Model Management
 

--- a/docs/user_guides/client_installation/index.md
+++ b/docs/user_guides/client_installation/index.md
@@ -44,9 +44,9 @@ You can install all the above profiles with the following command:
 pip install hopsworks[python,great-expectations,polars]
 ```
 
-## HSFS Java Library
+## Hopsworks Java Library
 
-If you want to interact with the Hopsworks Feature Store from environments such as Spark, Flink or Beam, you can use the Hopsworks Feature Store (HSFS) Java library.
+If you want to interact with the Hopsworks Feature Store from environments such as Spark, Flink or Beam, you can use the Hopsworks Feature Store (Hopsworks) Java library.
 
 !!! note "Feature Store Only"
 
@@ -54,7 +54,7 @@ If you want to interact with the Hopsworks Feature Store from environments such 
     Additionally each environment might restrict the supported API operation.
     You can see which API operation is supported by which environment [here](../fs/compute_engines.md)
 
-The HSFS library is available on the Hopsworks' Maven repository.
+The Hopsworks library is available on the Hopsworks' Maven repository.
 If you are using Maven as build tool, you can add the following in your `pom.xml` file:
 
 ```xml
@@ -75,9 +75,9 @@ If you are using Maven as build tool, you can add the following in your `pom.xml
 
 The library has different builds targeting different environments:
 
-### HSFS Java
+### Hopsworks Java
 
-The `artifactId` for the HSFS Java build is `hsfs`, if you are using Maven as build tool, you can add the following dependency:
+The `artifactId` for the Hopsworks Java build is `hsfs`, if you are using Maven as build tool, you can add the following dependency:
 
 ```xml
 <dependency>

--- a/docs/user_guides/fs/compute_engines.md
+++ b/docs/user_guides/fs/compute_engines.md
@@ -26,7 +26,7 @@ Hopsworks is aiming to provide functional parity between the computational engin
 | Data validation using Great Expectations for streaming dataframes | [`FeatureGroup.validate`][hsfs.feature_group.FeatureGroup.validate] <br/> [`FeatureGroup.insert_stream`][hsfs.feature_group.FeatureGroup.insert_stream] | - | - | - | - | - | `insert_stream` does not perform any data validation even when a expectation suite is attached. |
 | Stream ingestion | [`FeatureGroup.insert_stream`][hsfs.feature_group.FeatureGroup.insert_stream] | :white_check_mark: | - | :white_check_mark: | :white_check_mark: | :white_check_mark: | Python/Pandas/Polars has currently no notion of streaming. |
 | Reading from Streaming Storage Connectors | [`KafkaConnector.read_stream`][hsfs.storage_connector.KafkaConnector.read_stream] | :white_check_mark: | - | - | - | - | Python/Pandas/Polars has currently no notion of streaming. For Flink/Beam/Java only write operations are supported |
-| Reading training data from external storage other than S3 | [`FeatureView.get_training_data`][hsfs.feature_view.FeatureView.get_training_data] | :white_check_mark: | - | - | - | - | Reading training data that was written to external storage using a Storage Connector other than S3 can currently not be read using HSFS APIs, instead you will have to use the storage's native client. |
+| Reading training data from external storage other than S3 | [`FeatureView.get_training_data`][hsfs.feature_view.FeatureView.get_training_data] | :white_check_mark: | - | - | - | - | Reading training data that was written to external storage using a Storage Connector other than S3 can currently not be read using Hopsworks APIs, instead you will have to use the storage's native client. |
 | Reading External Feature Groups into Dataframe | [`ExternalFeatureGroup.read`][hsfs.feature_group.ExternalFeatureGroup.read] | :white_check_mark: | - | - | - | - | Reading an External Feature Group directly into a Pandas/Polars Dataframe is not supported, however, you can use the [Query API][hsfs.constructor.query.Query] to create Feature Views/Training Data containing External Feature Groups. |
 | Read Queries containing External Feature Groups into Dataframe | [`Query.read`][hsfs.constructor.query.Query.read] | :white_check_mark: | - | - | - | - | Reading a Query containing an External Feature Group directly into a Pandas/Polars Dataframe is not supported, however, you can use the Query to create Feature Views/Training Data and write the data to a Storage Connector, from where you can read up the data into a Pandas/Polars Dataframe. |
 
@@ -39,7 +39,7 @@ Head over to the [Getting Started Guide](https://colab.research.google.com/githu
 
 ### Python Outside Hopsworks
 
-Connecting to the Feature Store from any Python environment, such as your local environment or Google Colab, requires setting up an API Key and installing the HSFS Python client library.
+Connecting to the Feature Store from any Python environment, such as your local environment or Google Colab, requires setting up an API Key and installing the Hopsworks Python client library.
 The [Python integration guide](../integrations/python.md) explains step by step how to connect to the Feature Store from any Python environment.
 
 ## Spark

--- a/docs/user_guides/fs/data_source/creation/adls.md
+++ b/docs/user_guides/fs/data_source/creation/adls.md
@@ -7,7 +7,7 @@ The ADLS Gen2 filesystem stores its data in Azure Blob storage, ensuring low-cos
 In Hopsworks, you can access ADLS Gen2 by defining a Data Source and creating and granting permissions to a service principal.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a connection to your Azure ADLS filesystem.
-When you're finished, you'll be able to read files using Spark through HSFS APIs.
+When you're finished, you'll be able to read files using Spark through Hopsworks APIs.
 You can also use the connector to write out training data from the Feature Store, in order to make it accessible by third parties.
 
 !!! note

--- a/docs/user_guides/fs/data_source/creation/bigquery.md
+++ b/docs/user_guides/fs/data_source/creation/bigquery.md
@@ -7,7 +7,7 @@ BigQuery is Google Cloud's managed data warehouse supporting that lets you run a
 Such data warehouses are often the source of raw data for feature engineering pipelines.
 
 In this guide, you will configure a Data Source in Hopsworks to connect to your BigQuery project by saving the necessary information.
-When you're finished, you'll be able to execute queries and read results of BigQuery using Spark through HSFS APIs.
+When you're finished, you'll be able to execute queries and read results of BigQuery using Spark through Hopsworks APIs.
 
 The data source uses the Google `spark-bigquery-connector` behind the scenes.
 To read more about the spark connector, like the spark options or usage, check [Apache Spark SQL connector for Google BigQuery.](https://github.com/GoogleCloudDataproc/spark-bigquery-connector#usage 'github.com/GoogleCloudDataproc/spark-bigquery-connector')

--- a/docs/user_guides/fs/data_source/creation/gcs.md
+++ b/docs/user_guides/fs/data_source/creation/gcs.md
@@ -10,7 +10,7 @@ These objects are stored in containers called as `buckets`.
 These types of storages are often the source for raw data from which features can be engineered.
 
 In this guide, you will configure a Data Source in Hopsworks to connect to your GCS bucket by saving the necessary information.
-When you're finished, you'll be able to read files from the GCS bucket using Spark through HSFS APIs.
+When you're finished, you'll be able to read files from the GCS bucket using Spark through Hopsworks APIs.
 
 The Data Source uses the Google `gcs-connector-hadoop` behind the scenes.
 For more information, check out [Google Cloud Data Source for Spark and Hadoop](https://github.com/GoogleCloudDataproc/hadoop-connectors/tree/master/gcs#google-cloud-storage-connector-for-spark-and-hadoop 'google-cloud-storage-connector-for-spark-and-hadoop').

--- a/docs/user_guides/fs/data_source/creation/hopsfs.md
+++ b/docs/user_guides/fs/data_source/creation/hopsfs.md
@@ -10,7 +10,7 @@ When you create training datasets from features in the Feature Store the HopsFS 
 However, if you want to output data to a different dataset, you can define a new Data Source for that dataset.
 
 In this guide, you will configure a HopsFS Data Source in Hopsworks which points at a different directory on the file system than the Training Datasets directory.
-When you're finished, you'll be able to write training data to different locations in your cluster through HSFS APIs.
+When you're finished, you'll be able to write training data to different locations in your cluster through Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/jdbc.md
+++ b/docs/user_guides/fs/data_source/creation/jdbc.md
@@ -7,7 +7,7 @@ Using JDBC connections one can query and update data in a database, usually orie
 Examples of databases you can connect to using JDBC are MySQL, Postgres, Oracle, DB2, MongoDB or Microsoft SQLServer.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a JDBC connection to your database of choice.
-When you're finished, you'll be able to query the database using Spark through HSFS APIs.
+When you're finished, you'll be able to query the database using Spark through Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/kafka.md
+++ b/docs/user_guides/fs/data_source/creation/kafka.md
@@ -6,7 +6,7 @@ Apache Kafka is a distributed event store and stream-processing platform.
 It's a very popular framework for handling realtime data streams and is often used as a message broker for events coming from production systems until they are being processed and either loaded into a data warehouse or aggregated into features for Machine Learning.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a connection to your Kafka cluster.
-When you're finished, you'll be able to read from Kafka topics in your cluster using Spark through HSFS APIs.
+When you're finished, you'll be able to read from Kafka topics in your cluster using Spark through Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/redshift.md
+++ b/docs/user_guides/fs/data_source/creation/redshift.md
@@ -8,7 +8,7 @@ Data warehouses are often the source of raw data for feature engineering pipelin
 However, Redshift is not viable as an online feature store that serves features to models in production, with its columnar database layout its latency is too high compared to OLTP databases or key-value stores.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a connection to your AWS Redshift cluster.
-When you're finished, you'll be able to query the database using Spark through HSFS APIs.
+When you're finished, you'll be able to query the database using Spark through Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.
@@ -27,7 +27,7 @@ Before you begin this guide you'll need to retrieve the following information fr
 - **Authentication method:** There are three options available for authenticating with the Redshift cluster.
   The first option is to configure a username and a password.
   The second option is to configure an IAM role.
-  With IAM roles, Jobs or notebooks launched on Hopsworks do not need to explicitly authenticate with Redshift, as the HSFS library will transparently use the IAM role to acquire a temporary credential to authenticate the specified user.
+  With IAM roles, Jobs or notebooks launched on Hopsworks do not need to explicitly authenticate with Redshift, as the Hopsworks library will transparently use the IAM role to acquire a temporary credential to authenticate the specified user.
   Read more about IAM roles in our [AWS credentials pass-through guide](../../../../setup_installation/admin/roleChaining.md).
   Lastly, option `Instance Role` will use the default ARN Role configured for the cluster instance.
 

--- a/docs/user_guides/fs/data_source/creation/s3.md
+++ b/docs/user_guides/fs/data_source/creation/s3.md
@@ -12,7 +12,7 @@ This has the advantage that cheap storage can be turned into a cloud native data
 These kinds of storages are often the source for raw data from which features can be engineered.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a connection to your AWS S3 bucket.
-When you're finished, you'll be able to read files using Spark through HSFS APIs.
+When you're finished, you'll be able to read files using Spark through Hopsworks APIs.
 You can also use the connector to write out training data from the Feature Store, in order to make it accessible by third parties.
 
 !!! note

--- a/docs/user_guides/fs/data_source/creation/snowflake.md
+++ b/docs/user_guides/fs/data_source/creation/snowflake.md
@@ -8,7 +8,7 @@ Data warehouses are often the source of raw data for feature engineering pipelin
 However, Snowflake is not viable as an online feature store that serves features to models in production, with its columnar database layout its latency is too high compared to OLTP databases or key-value stores.
 
 In this guide, you will configure a Data Source in Hopsworks to save all the authentication information needed in order to set up a connection to your Snowflake database.
-When you're finished, you'll be able to query the database using Spark through HSFS APIs.
+When you're finished, you'll be able to query the database using Spark through Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/sql.md
+++ b/docs/user_guides/fs/data_source/creation/sql.md
@@ -7,7 +7,7 @@ Supported database types are **MySQL**, **PostgreSQL**, and **Oracle**.
 Using this connector, you can query and update data in your relational database from Hopsworks.
 
 In this guide, you will configure a Data Source in Hopsworks to securely store the authentication information needed to set up a connection to your database instance.
-When you're finished, you'll be able to query your SQL database using HSFS APIs.
+When you're finished, you'll be able to query your SQL database using Hopsworks APIs.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/unity_catalog.md
+++ b/docs/user_guides/fs/data_source/creation/unity_catalog.md
@@ -1,0 +1,72 @@
+# How-To set up a Unity Catalog Data Source
+
+## Introduction
+
+A Unity Catalog data source provides integration to [Databricks Unity Catalog](https://docs.databricks.com/aws/en/data-governance/unity-catalog/).
+Unity Catalog is Databricks' unified governance layer for data and AI assets, organised as a catalog → schema → table hierarchy.
+
+In this guide, you will configure a Data Source in Hopsworks that points at a Databricks workspace.
+Once configured, you can browse catalogs, schemas, and tables, and mount Delta tables as external Feature Groups whose data is read through the Arrow Flight query service.
+
+!!! note
+    Only Delta-formatted Unity Catalog tables are supported in this release.
+    Managed non-Delta tables are filtered out when browsing.
+
+!!! note
+    Currently, it is only possible to create data sources in the Hopsworks UI.
+    You cannot create a data source programmatically.
+
+!!! warning
+    Direct Spark reads from Unity Catalog are not supported in this release.
+    Reads flow through the Arrow Flight query service, which uses DuckDB's `unity_catalog` and `delta` extensions.
+
+## Prerequisites
+
+Before you begin, you need:
+
+- **Databricks workspace URL**, for example `https://<workspace>.cloud.databricks.com`.
+- **Personal access token** with at least `USE CATALOG`, `USE SCHEMA`, and `SELECT` privileges on the catalogs, schemas, and Delta tables you want to expose.
+- **A catalog name** containing Delta tables you want to mount, optionally set as the default catalog on the connector.
+
+The personal access token is stored encrypted in the Hopsworks secrets table — it is never written to the connector table in plaintext.
+Rotation is a manual operation in this release: when the token expires, edit the connector and paste in a fresh one.
+
+## Feature flag
+
+Unity Catalog connectors are gated by the `enable_unity_catalog_storage_connectors` Hopsworks variable.
+An administrator must set it to `true` in the admin variables UI before the connector type appears in the create form.
+
+## Creation in the UI
+
+### Step 1: Set up new Data Source
+
+Head to the Data Source view in Hopsworks (1) and set up a new data source (2).
+
+<figure markdown>
+  ![Data Source Creation](../../../../assets/images/guides/fs/data_source/data_source_overview.png)
+  <figcaption>The Data Source view in the user interface</figcaption>
+</figure>
+
+### Step 2: Enter source details
+
+Enter the details for your Unity Catalog workspace.
+Start by giving it a unique **name** and an optional **description**.
+
+1. Select "Databricks Unity Catalog" as the storage type.
+2. **Databricks Workspace URL** — the full `https://` URL of your workspace.
+3. **Access Token** — a Databricks personal access token; the field is masked and stored encrypted.
+4. **Default Catalog** — optional; the Unity Catalog catalog to pre-select when browsing.
+5. **Arguments** — optional key/value pairs passed through to the query service.
+6. Click "Save Credentials".
+
+On save, Hopsworks calls the Unity Catalog `/catalogs` endpoint using the provided token; an HTTP 2xx response is required for the connector to be accepted.
+
+### Step 3: Browse and mount a table
+
+After saving, open the connector and click **Configure**.
+The "Catalog" dropdown lists catalogs visible to your token; pick one and the schema/table browser lists Delta tables grouped by schema.
+Select a table to create an external Feature Group pointing at it — reads will flow through the Arrow Flight query service.
+
+## Next Steps
+
+Move on to the [usage guide for data sources](../usage.md) to see how you can use your newly created Unity Catalog connector.

--- a/docs/user_guides/fs/data_source/creation/unity_catalog.md
+++ b/docs/user_guides/fs/data_source/creation/unity_catalog.md
@@ -36,9 +36,11 @@ Before you begin you need all of the following — the first three are on the Da
   Without this toggle, every call to `/api/2.1/unity-catalog/temporary-table-credentials` returns `403 Forbidden` for any principal.
   This is an account-admin setting — workspace admin alone cannot flip it.
 - **`EXTERNAL USE SCHEMA` grant on the schemas you want to read.** In Databricks SQL:
+
   ```sql
   GRANT EXTERNAL USE SCHEMA ON SCHEMA <catalog>.<schema> TO `<principal>`;
   ```
+
   where `<principal>` is the user (or service principal) that owns the PAT you are about to paste into Hopsworks. Without this grant the temporary-table-credentials endpoint returns `400 Bad Request`.
 - **`USE CATALOG`, `USE SCHEMA`, and `SELECT` grants** on the specific catalog / schema / tables you want to mount.
 - **Delta format.** Unity Catalog tables backed by Iceberg, non-Delta file formats, views, or streaming / materialised views cannot be read through this connector in v1.

--- a/docs/user_guides/fs/data_source/creation/unity_catalog.md
+++ b/docs/user_guides/fs/data_source/creation/unity_catalog.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-A Unity Catalog data source provides integration to [Databricks Unity Catalog](https://docs.databricks.com/aws/en/data-governance/unity-catalog/).
+A Unity Catalog data source provides integration with [Databricks Unity Catalog](https://docs.databricks.com/aws/en/data-governance/unity-catalog/).
 Unity Catalog is Databricks' unified governance layer for data and AI assets, organised as a catalog → schema → table hierarchy.
 
 In this guide, you will configure a Data Source in Hopsworks that points at a Databricks workspace.
@@ -31,7 +31,10 @@ Before you begin you need all of the following — the first three are on the Da
 
 ### Databricks side
 
-- **External Data Access enabled on the metastore.** In the Databricks account console, go to Catalog → the metastore backing your workspace → Details, and turn on "External data access". Without this toggle, every call to `/api/2.1/unity-catalog/temporary-table-credentials` returns `403 Forbidden` for any principal. This is an account-admin setting — workspace admin alone cannot flip it.
+- **External Data Access enabled on the metastore.**
+  In the Databricks account console, go to Catalog → the metastore backing your workspace → Details, and turn on "External data access".
+  Without this toggle, every call to `/api/2.1/unity-catalog/temporary-table-credentials` returns `403 Forbidden` for any principal.
+  This is an account-admin setting — workspace admin alone cannot flip it.
 - **`EXTERNAL USE SCHEMA` grant on the schemas you want to read.** In Databricks SQL:
   ```sql
   GRANT EXTERNAL USE SCHEMA ON SCHEMA <catalog>.<schema> TO `<principal>`;

--- a/docs/user_guides/fs/data_source/creation/unity_catalog.md
+++ b/docs/user_guides/fs/data_source/creation/unity_catalog.md
@@ -8,13 +8,14 @@ Unity Catalog is Databricks' unified governance layer for data and AI assets, or
 In this guide, you will configure a Data Source in Hopsworks that points at a Databricks workspace.
 Once configured, you can browse catalogs, schemas, and tables, and mount Delta tables as external Feature Groups whose data is read through the Arrow Flight query service.
 
-!!! note
-    Only Delta-formatted Unity Catalog tables are supported in this release.
-    Managed non-Delta tables are filtered out when browsing.
+!!! warning "Databricks on AWS only"
+    Unity Catalog is currently only supported on **Databricks on AWS**.
+    Databricks on Azure and Databricks on GCP are not supported in this release — their Unity Catalog temporary-table-credentials responses use cloud-specific credential shapes (Azure SAS tokens, GCP service-account tokens) that the Hopsworks Arrow Flight read path does not yet handle.
+    If you point this connector at a non-AWS Databricks workspace the browse flow may succeed but every preview and feature-group read will fail.
 
 !!! note
-    Only AWS-backed Unity Catalog metastores are supported in this release.
-    Azure ADLS and GCP GCS backed workspaces will surface a clear error and need follow-up work on the read path.
+    Only Delta-formatted Unity Catalog tables are supported in this release.
+    Managed non-Delta tables, Iceberg tables, views, streaming tables, and materialised views are filtered out when browsing.
 
 !!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.

--- a/docs/user_guides/fs/data_source/creation/unity_catalog.md
+++ b/docs/user_guides/fs/data_source/creation/unity_catalog.md
@@ -13,23 +13,41 @@ Once configured, you can browse catalogs, schemas, and tables, and mount Delta t
     Managed non-Delta tables are filtered out when browsing.
 
 !!! note
+    Only AWS-backed Unity Catalog metastores are supported in this release.
+    Azure ADLS and GCP GCS backed workspaces will surface a clear error and need follow-up work on the read path.
+
+!!! note
     Currently, it is only possible to create data sources in the Hopsworks UI.
     You cannot create a data source programmatically.
 
 !!! warning
     Direct Spark reads from Unity Catalog are not supported in this release.
-    Reads flow through the Arrow Flight query service, which uses DuckDB's `unity_catalog` and `delta` extensions.
+    Reads flow through the Arrow Flight query service, which resolves each Delta table via the Unity Catalog REST API and reads it using the `deltalake` Python package (delta-rs) against the S3 location that Databricks returns.
 
 ## Prerequisites
 
-Before you begin, you need:
+Before you begin you need all of the following — the first three are on the Databricks side and are the most common source of 400 / 403 errors from the read path.
+
+### Databricks side
+
+- **External Data Access enabled on the metastore.** In the Databricks account console, go to Catalog → the metastore backing your workspace → Details, and turn on "External data access". Without this toggle, every call to `/api/2.1/unity-catalog/temporary-table-credentials` returns `403 Forbidden` for any principal. This is an account-admin setting — workspace admin alone cannot flip it.
+- **`EXTERNAL USE SCHEMA` grant on the schemas you want to read.** In Databricks SQL:
+  ```sql
+  GRANT EXTERNAL USE SCHEMA ON SCHEMA <catalog>.<schema> TO `<principal>`;
+  ```
+  where `<principal>` is the user (or service principal) that owns the PAT you are about to paste into Hopsworks. Without this grant the temporary-table-credentials endpoint returns `400 Bad Request`.
+- **`USE CATALOG`, `USE SCHEMA`, and `SELECT` grants** on the specific catalog / schema / tables you want to mount.
+- **Delta format.** Unity Catalog tables backed by Iceberg, non-Delta file formats, views, or streaming / materialised views cannot be read through this connector in v1.
+
+### Hopsworks side
 
 - **Databricks workspace URL**, for example `https://<workspace>.cloud.databricks.com`.
-- **Personal access token** with at least `USE CATALOG`, `USE SCHEMA`, and `SELECT` privileges on the catalogs, schemas, and Delta tables you want to expose.
-- **A catalog name** containing Delta tables you want to mount, optionally set as the default catalog on the connector.
+- **Personal access token** for the principal to which the grants above were issued.
+- **A catalog name** containing the Delta tables you want to mount. It is optional but recommended to set this as the default catalog on the connector so the UI opens the browse view directly.
+- Optional: an **AWS region** (for example `us-west-2`). If you omit it, the backend guesses the region by parsing the STS session-token returned with the table credentials. For FIPS regions or for any workspace where the guess has been wrong once, set the region explicitly on the connector.
 
-The personal access token is stored encrypted in the Hopsworks secrets table — it is never written to the connector table in plaintext.
-Rotation is a manual operation in this release: when the token expires, edit the connector and paste in a fresh one.
+The personal access token is stored encrypted in the Hopsworks `secrets` table — it is never written to the connector table in plaintext.
+PAT rotation is manual in this release: when the token expires, edit the connector and paste in a fresh one. Unity Catalog PATs are typically short-lived (hours to a few days), so expect to do this periodically.
 
 ## Feature flag
 
@@ -56,8 +74,9 @@ Start by giving it a unique **name** and an optional **description**.
 2. **Databricks Workspace URL** — the full `https://` URL of your workspace.
 3. **Access Token** — a Databricks personal access token; the field is masked and stored encrypted.
 4. **Default Catalog** — optional; the Unity Catalog catalog to pre-select when browsing.
-5. **Arguments** — optional key/value pairs passed through to the query service.
-6. Click "Save Credentials".
+5. **AWS Region** — optional; set explicitly (for example `us-west-2`) when the backend's region guess from the STS session-token is wrong or your workspace is in a FIPS region. Leave empty to use the guess.
+6. **Arguments** — optional key/value pairs passed through to the query service.
+7. Click "Save Credentials".
 
 On save, Hopsworks calls the Unity Catalog `/catalogs` endpoint using the provided token; an HTTP 2xx response is required for the connector to be accepted.
 

--- a/docs/user_guides/fs/data_source/index.md
+++ b/docs/user_guides/fs/data_source/index.md
@@ -60,6 +60,12 @@ For GCP the following storage systems are supported:
 1. [BigQuery](creation/bigquery.md): Query BigQuery databases and tables using SQL.
 2. [GCS](creation/gcs.md): Read data from a variety of file based storage in Google Cloud Storage such as parquet or CSV.
 
+## Databricks
+
+For Databricks the following storage systems are supported:
+
+1. [Unity Catalog](creation/unity_catalog.md): Browse Unity Catalog catalogs, schemas, and Delta tables, and mount them as external feature groups.
+
 ## Next Steps
 
 Move on to the [Configuration and Creation Guides](creation/jdbc.md) to learn how to set up a data source.

--- a/docs/user_guides/fs/data_source/index.md
+++ b/docs/user_guides/fs/data_source/index.md
@@ -64,7 +64,7 @@ For GCP the following storage systems are supported:
 
 For Databricks **on AWS** the following storage systems are supported:
 
-1. [Unity Catalog](creation/unity_catalog.md): Browse Unity Catalog catalogs, schemas, and Delta tables, and mount them as external feature groups.
+1. [Unity Catalog](creation/unity_catalog.md): Browse Unity Catalog catalogs, schemas, and Delta tables, and mount them as external Feature Groups.
 
 Databricks on Azure and Databricks on GCP are not supported yet — see the [Unity Catalog guide](creation/unity_catalog.md) for the specific reasons and the status of follow-up work.
 

--- a/docs/user_guides/fs/data_source/index.md
+++ b/docs/user_guides/fs/data_source/index.md
@@ -60,11 +60,13 @@ For GCP the following storage systems are supported:
 1. [BigQuery](creation/bigquery.md): Query BigQuery databases and tables using SQL.
 2. [GCS](creation/gcs.md): Read data from a variety of file based storage in Google Cloud Storage such as parquet or CSV.
 
-## Databricks
+## Databricks (AWS only)
 
-For Databricks the following storage systems are supported:
+For Databricks **on AWS** the following storage systems are supported:
 
 1. [Unity Catalog](creation/unity_catalog.md): Browse Unity Catalog catalogs, schemas, and Delta tables, and mount them as external feature groups.
+
+Databricks on Azure and Databricks on GCP are not supported yet — see the [Unity Catalog guide](creation/unity_catalog.md) for the specific reasons and the status of follow-up work.
 
 ## Next Steps
 

--- a/docs/user_guides/fs/data_source/usage.md
+++ b/docs/user_guides/fs/data_source/usage.md
@@ -71,7 +71,7 @@ Additionally, for reading file based data sources, another way to read the data 
 This method can be used if you are reading the data directly through Spark.
 
 Firstly, it handles the setup of all Spark configurations or properties necessary for a particular type of connector and prepares the absolute path to read from, along with bucket name and the appropriate file scheme of the data source.
-A Spark session can handle only one configuration setup at a time, so HSFS cannot set the Spark configurations when retrieving the connector since it would lead to only always initialising the last connector being retrieved.
+A Spark session can handle only one configuration setup at a time, so Hopsworks cannot set the Spark configurations when retrieving the connector since it would lead to only always initialising the last connector being retrieved.
 Instead, user can do this setup explicitly with the `prepare_spark` method and therefore potentially use multiple connectors in one Spark session. `prepare_spark` handles only one bucket associated with that particular connector, however, it is possible to set up multiple connectors with different types as long as their Spark properties do not interfere with each other.
 So, for example a S3 connector and a Snowflake connector can be used in the same session, without calling `prepare_spark` multiple times, as the properties don’t interfere with each other.
 

--- a/docs/user_guides/fs/feature_group/create.md
+++ b/docs/user_guides/fs/feature_group/create.md
@@ -7,21 +7,21 @@ description: Documentation on how to create a Feature Group and the different AP
 ## Introduction
 
 In this guide you will learn how to create and register a feature group with Hopsworks.
-This guide covers creating a feature group using the HSFS APIs as well as the user interface.
+This guide covers creating a feature group using the Hopsworks APIs as well as the user interface.
 
 ## Prerequisites
 
 Before you begin this guide we suggest you read the [Feature Group](../../../concepts/fs/feature_group/fg_overview.md) concept page to understand what a feature group is and how it fits in the ML pipeline.
 
-## Create using the HSFS APIs
+## Create using the Hopsworks APIs
 
-To create a feature group using the HSFS APIs, you need to provide a Pandas, Polars or Spark DataFrame.
+To create a feature group using the Hopsworks APIs, you need to provide a Pandas, Polars or Spark DataFrame.
 The DataFrame will contain all the features you want to register within the feature group, as well as the primary key, event time and partition key.
 
 ### Create a Feature Group
 
 The first step to create a feature group is to create the API metadata object representing a feature group.
-Using the HSFS API you can execute:
+Using the Hopsworks API you can execute:
 
 #### Batch Write API
 
@@ -351,7 +351,7 @@ fg.insert(df)
 ```
 
 The save method takes in input a Pandas, Polars or Spark DataFrame.
-HSFS will use the DataFrame columns and types to determine the name and types of features, primary key, partition key and event time.
+Hopsworks will use the DataFrame columns and types to determine the name and types of features, primary key, partition key and event time.
 
 The DataFrame *must* contain the columns specified as primary keys, partition key and event time in the `create_feature_group` call.
 

--- a/docs/user_guides/fs/feature_group/create_external.md
+++ b/docs/user_guides/fs/feature_group/create_external.md
@@ -7,17 +7,17 @@ description: Documentation on how to create an external feature group in Hopswor
 ## Introduction
 
 In this guide you will learn how to create and register an external feature group with Hopsworks.
-This guide covers creating an external feature group using the HSFS APIs as well as the user interface.
+This guide covers creating an external feature group using the Hopsworks APIs as well as the user interface.
 
 ## Prerequisites
 
 Before you begin this guide we suggest you read the [External Feature Group](../../../concepts/fs/feature_group/external_fg.md) concept page to understand what a feature group is and how it fits in the ML pipeline.
 
-## Create using the HSFS APIs
+## Create using the Hopsworks APIs
 
 ### Retrieve the Data Source
 
-To create an external feature group using the HSFS APIs you need to provide an existing [data source](../data_source/index.md).
+To create an external feature group using the Hopsworks APIs you need to provide an existing [data source](../data_source/index.md).
 
 === "Python"
 

--- a/docs/user_guides/fs/feature_group/create_spine.md
+++ b/docs/user_guides/fs/feature_group/create_spine.md
@@ -12,7 +12,7 @@ In this guide you will learn how to create and register a Spine Group with Hopsw
 
 Before you begin this guide we suggest you read the [Spine Group](../../../concepts/fs/feature_group/spine_group.md) concept page to understand what a Spine Group is and how it fits in the ML pipeline.
 
-## Create using the HSFS APIs
+## Create using the Hopsworks APIs
 
 ### Create a Spine Group
 
@@ -55,7 +55,7 @@ You just need to make sure it has the same schema.
 
 !!! warning "Python support"
 
-    Currently the HSFS library does not support usage of Spine Groups for training data creation or batch data retrieval in the Python engine.
+    Currently the Hopsworks library does not support usage of Spine Groups for training data creation or batch data retrieval in the Python engine.
     However, it is supported to create Spine Groups from the Python engine.
 
 ### API Reference

--- a/docs/user_guides/fs/feature_group/deprecation.md
+++ b/docs/user_guides/fs/feature_group/deprecation.md
@@ -9,18 +9,18 @@ description: Documentation on how to deprecate a feature group in Hopsworks.
 To discourage the usage of specific feature groups it is possible to deprecate them.
 When a feature group is deprecated, user will be warned when they try to use it or use a feature view that depends on it.
 
-In this guide you will learn how to deprecate a feature group within Hopsworks, showing examples in HSFS APIs as well as the user interface.
+In this guide you will learn how to deprecate a feature group within Hopsworks, showing examples in Hopsworks APIs as well as the user interface.
 
 ## Prerequisites
 
 Before you begin this guide it is expected that there is an existing feature group in your project.
 You can familiarize yourself with [the creation of a feature group](./create.md) in the user guide.
 
-## Deprecate using the HSFS APIs
+## Deprecate using the Hopsworks APIs
 
 ### Retrieve the feature group
 
-To deprecate a feature group using the HSFS APIs you need to provide a [Feature Group](../../../concepts/fs/feature_group/fg_overview.md).
+To deprecate a feature group using the Hopsworks APIs you need to provide a [Feature Group](../../../concepts/fs/feature_group/fg_overview.md).
 
 === "Python"
 

--- a/docs/user_guides/fs/feature_group/notification.md
+++ b/docs/user_guides/fs/feature_group/notification.md
@@ -9,18 +9,18 @@ description: Documentation on Change Data Capture for feature groups in Hopswork
 Changes to online-enabled feature groups can be captured by listening to events on specified topics.
 This optimizes the user experience by allowing users to proactively make predictions as soon as there is an update on the features.
 
-In this guide you will learn how to enable Change Data Capture (CDC) for online feature groups within Hopsworks, showing examples in HSFS APIs as well as the user interface.
+In this guide you will learn how to enable Change Data Capture (CDC) for online feature groups within Hopsworks, showing examples in Hopsworks APIs as well as the user interface.
 
 ## Prerequisites
 
 Before you begin this guide we suggest you read the [Feature Group](../../../concepts/fs/feature_group/fg_overview.md) concept page to understand what a feature group is and how it fits in the ML pipeline.
 Subsequently [create a Kafka topic](../../projects/kafka/create_topic.md), this topic will be used for storing Change Data Capture events.
 
-## Using HSFS APIs
+## Using Hopsworks APIs
 
 ### Create a Feature Group with Change Data Capture using Python
 
-To enable Change Data Capture for an online-enabled feature group using the HSFS APIs you need to [create a feature group](./create.md) and set the `notification_topic_name` properties value to the previously created topic.
+To enable Change Data Capture for an online-enabled feature group using the Hopsworks APIs you need to [create a feature group](./create.md) and set the `notification_topic_name` properties value to the previously created topic.
 
 === "Python"
 

--- a/docs/user_guides/fs/feature_group/online_ingestion_observability.md
+++ b/docs/user_guides/fs/feature_group/online_ingestion_observability.md
@@ -9,7 +9,7 @@ description: Documentation on Online ingestion observability in Hopsworks.
 Knowing when ingested data becomes available for online serving—and understanding the cause of any ingestion failures—is crucial for users.
 To address this, the Hopsworks API provides observability features for online ingestion, allowing you to monitor ingestion status and troubleshoot issues.
 
-This guide explains how to use these observability features for online feature groups in Hopsworks, with examples using both the HSFS APIs and the user interface.
+This guide explains how to use these observability features for online feature groups in Hopsworks, with examples using both the Hopsworks APIs and the user interface.
 
 ## Prerequisites
 

--- a/docs/user_guides/fs/feature_view/query.md
+++ b/docs/user_guides/fs/feature_view/query.md
@@ -1,6 +1,6 @@
 # Query vs DataFrame
 
-HSFS provides a DataFrame API to ingest data into the Hopsworks Feature Store.
+Hopsworks provides a DataFrame API to ingest data into the Hopsworks Feature Store.
 You can also retrieve feature data in a DataFrame, that can either be used directly to train models or [materialized to file(s)](./training-data.md) for later use to train models.
 
 The idea of the Feature Store is to have pre-computed features available for both training and serving models.
@@ -61,7 +61,7 @@ The APIs allow you to specify which features to select from which feature group,
 
 If a data scientist wants to modify a new feature that is not available in the feature store, she can write code to compute the new feature (using existing features or external data) and ingest the new feature values into the feature store.
 If the new feature is based solely on existing feature values in the Feature Store, we call it a derived feature.
-The same HSFS APIs can be used to compute derived features as well as features using external data sources.
+The same Hopsworks APIs can be used to compute derived features as well as features using external data sources.
 
 ## The Query Abstraction
 
@@ -94,7 +94,7 @@ Selecting features from a feature group is a lazy operation, returning a query w
 #### Join
 
 Similarly, joins return query objects.
-The simplest join in one where we join all of the features together from two different feature groups without specifying a join key - `HSFS` will infer the join key as a common primary key between the two feature groups.
+The simplest join in one where we join all of the features together from two different feature groups without specifying a join key - `Hopsworks` will infer the join key as a common primary key between the two feature groups.
 By default, Hopsworks will use the maximal matching subset of the primary keys of the two feature groups as joining key(s), if not specified otherwise.
 
 === "Python"

--- a/docs/user_guides/integrations/databricks/configuration.md
+++ b/docs/user_guides/integrations/databricks/configuration.md
@@ -3,13 +3,13 @@ description: Documentation on how to configure a Databricks cluster to read and 
 ---
 # Databricks Integration
 
-Users can configure their Databricks clusters to write the results of feature engineering pipelines in the Hopsworks Feature Store using HSFS.
+Users can configure their Databricks clusters to write the results of feature engineering pipelines in the Hopsworks Feature Store using Hopsworks.
 Configuring a Databricks cluster can be done from the Hopsworks Feature Store UI.
 This guide explains each step.
 
 ## Prerequisites
 
-In order to be able to configure a Databricks cluster to use the Feature Store of your Hopsworks instance, it is necessary to ensure networking is setup correctly between the instances and that the Databricks cluster has access to the Hopsworks API key to perform requests with HSFS from Databricks to Hopsworks.
+In order to be able to configure a Databricks cluster to use the Feature Store of your Hopsworks instance, it is necessary to ensure networking is setup correctly between the instances and that the Databricks cluster has access to the Hopsworks API key to perform requests with Hopsworks from Databricks to Hopsworks.
 
 ### Networking
 
@@ -17,7 +17,7 @@ If you haven't done so already, follow the networking guides for either [AWS](ne
 
 ### Hopsworks API key
 
-In order for the Feature Store API to be able to communicate with the user's Hopsworks instance, the client library (HSFS) needs to have access to a previously generated API key from Hopsworks.
+In order for the Feature Store API to be able to communicate with the user's Hopsworks instance, the client library (Hopsworks) needs to have access to a previously generated API key from Hopsworks.
 For ways to setup and store the Hopsworks API key, please refer to the [API key guide for Databricks](api_key.md).
 
 ## Databricks API key
@@ -82,7 +82,7 @@ Hopsworks `Data Owners` are allowed to configure clusters for other project user
 
 During the cluster configuration the following steps will be taken:
 
-- Upload an archive to DBFS containing the necessary Jars for HSFS and HopsFS to be able to read and write from the Hopsworks Feature Store
+- Upload an archive to DBFS containing the necessary Jars for Hopsworks and HopsFS to be able to read and write from the Hopsworks Feature Store
 - Add an initScript to configure the Jars when the cluster is started
 - Install `hsfs` python library
 - Configure the necessary Spark properties to authenticate and communicate with the Feature Store

--- a/docs/user_guides/integrations/spark.md
+++ b/docs/user_guides/integrations/spark.md
@@ -11,7 +11,7 @@ This guide explains step by step how to connect to the Feature Store from an ext
 In the *Project Settings*, select the *integration* tab and scroll to the *Configure Spark Integration* section.
 Click on *Download client Jars*.
 This will start the download of the *client.tar.gz* archive.
-The archive contains two jar files for HopsFS, the Apache Hudi jar and the Java version of the HSFS library.
+The archive contains two jar files for HopsFS, the Apache Hudi jar and the Java version of the Hopsworks library.
 You should upload these libraries to your Spark cluster and attach them as local resources to your Job.
 If you are using `spark-submit`, you should specify the `--jar` option.
 For more details see: [Spark Dependency Management](https://spark.apache.org/docs/latest/submitting-applications.html#advanced-dependency-management).
@@ -62,10 +62,10 @@ spark.hadoop.hive.metastore.uris                    thrift://[metastore_ip]:[met
 
 ## PySpark
 
-To use PySpark, install the HSFS Python library which can be found on [PyPi](https://pypi.org/project/hsfs/).
+To use PySpark, install the Hopsworks Python library which can be found on [PyPi](https://pypi.org/project/hsfs/).
 
 !!! attention "Matching Hopsworks version"
-    The **major version of `HSFS`** needs to match the **major version of Hopsworks**.
+    The **major version of `Hopsworks`** needs to match the **major version of Hopsworks**.
 
 ## Generating an API Key
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
                   - SQL: user_guides/fs/data_source/creation/sql.md
                   - CRM, Sales & Analytics: user_guides/fs/data_source/creation/crm_sales_analytics.md
                   - REST API: user_guides/fs/data_source/creation/rest_api.md
+                  - Unity Catalog: user_guides/fs/data_source/creation/unity_catalog.md
               - Usage: user_guides/fs/data_source/usage.md
           - Feature Group:
               - user_guides/fs/feature_group/index.md


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/FSTORE-2017

## Summary

- New user guide `docs/user_guides/fs/data_source/creation/unity_catalog.md` with prerequisites, the admin feature-flag note, step-by-step UI walkthrough, and the Delta-tables-only + manual-token-rotation caveats.
- Data source index gets a new Databricks section linking to the Unity Catalog guide.
- External-feature-group concept prose adds Databricks Unity Catalog (Delta tables) to the supported-sources list.
- `mkdocs.yml` nav updated.

Note: the `unity_catalog_creation.png` screenshot is not yet included — to be captured from the live UI once the frontend PR ships.

## Test plan
- [ ] `touch docs/javadoc && uv run mkdocs build -s && rm docs/javadoc` builds cleanly
- [ ] `npx markdownlint-cli2 "**/*.md"` passes

Companion PRs:
- hopsworks-ee (backend)
- hopsworks-api (Python SDK)
- flyingduck (query engine)
- hopsworks-front, loadtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)