### PR TITLE
 [HWORKS-2731] Document HopsFS access path for shared datasets

### DIFF
--- a/docs/user_guides/projects/jobs/notebook_job.md
+++ b/docs/user_guides/projects/jobs/notebook_job.md
@@ -209,7 +209,8 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/notebook_job.md
+++ b/docs/user_guides/projects/jobs/notebook_job.md
@@ -209,7 +209,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/notebook_job.md
+++ b/docs/user_guides/projects/jobs/notebook_job.md
@@ -209,7 +209,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/notebook_job.md
+++ b/docs/user_guides/projects/jobs/notebook_job.md
@@ -209,6 +209,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -203,7 +203,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -203,6 +203,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -203,7 +203,8 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -203,7 +203,7 @@ The following table describes the job configuration parameters for a PYTHON job.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -248,6 +248,7 @@ The following table describes the job configuration parameters for a RAY job.
 ## Accessing project data
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -248,7 +248,8 @@ The following table describes the job configuration parameters for a RAY job.
 ## Accessing project data
 
 If HopsFS is mounted, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-If HopsFS is mounted, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+If HopsFS is mounted, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
+The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -248,8 +248,7 @@ The following table describes the job configuration parameters for a RAY job.
 ## Accessing project data
 
 If HopsFS is mounted, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets 
-directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -248,8 +248,8 @@ The following table describes the job configuration parameters for a RAY job.
 ## Accessing project data
 
 If HopsFS is mounted, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-If HopsFS is mounted, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
-The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets 
+directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -248,7 +248,7 @@ The following table describes the job configuration parameters for a RAY job.
 ## Accessing project data
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jobs/ray_job.md
+++ b/docs/user_guides/projects/jobs/ray_job.md
@@ -247,8 +247,8 @@ The following table describes the job configuration parameters for a RAY job.
 
 ## Accessing project data
 
-The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+If HopsFS is mounted, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your script.
+If HopsFS is mounted, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
 
 ## API Reference
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -100,6 +100,7 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -100,7 +100,7 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -100,7 +100,8 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -100,7 +100,7 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
 ### Absolute paths
 
 The project datasets are mounted under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv` in your notebook.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
 
 ### Relative paths
 

--- a/docs/user_guides/projects/jupyter/ray_notebook.md
+++ b/docs/user_guides/projects/jupyter/ray_notebook.md
@@ -162,5 +162,4 @@ In the Ray Dashboard, you can monitor the resources used  by code you are runnin
 ## Accessing project data
 
 If HopsFS is mounted in the Ray containers, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
-If HopsFS is mounted in the Ray containers, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
-The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.

--- a/docs/user_guides/projects/jupyter/ray_notebook.md
+++ b/docs/user_guides/projects/jupyter/ray_notebook.md
@@ -161,5 +161,5 @@ In the Ray Dashboard, you can monitor the resources used  by code you are runnin
 
 ## Accessing project data
 
-The project datasets are mounted under `/hopsfs` in the Ray containers, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+If HopsFS is mounted in the Ray containers, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
+If HopsFS is mounted in the Ray containers, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.

--- a/docs/user_guides/projects/jupyter/ray_notebook.md
+++ b/docs/user_guides/projects/jupyter/ray_notebook.md
@@ -162,4 +162,5 @@ In the Ray Dashboard, you can monitor the resources used  by code you are runnin
 ## Accessing project data
 
 If HopsFS is mounted in the Ray containers, project datasets are available under `/hopsfs`, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
-If HopsFS is mounted in the Ray containers, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.
+If HopsFS is mounted in the Ray containers, shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>`.
+The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.

--- a/docs/user_guides/projects/jupyter/ray_notebook.md
+++ b/docs/user_guides/projects/jupyter/ray_notebook.md
@@ -162,4 +162,4 @@ In the Ray Dashboard, you can monitor the resources used  by code you are runnin
 ## Accessing project data
 
 The project datasets are mounted under `/hopsfs` in the Ray containers, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
-Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted. The shared datasets directory is also available through the `SHARED_DATASETS_DIR` environment variable.

--- a/docs/user_guides/projects/jupyter/ray_notebook.md
+++ b/docs/user_guides/projects/jupyter/ray_notebook.md
@@ -162,3 +162,4 @@ In the Ray Dashboard, you can monitor the resources used  by code you are runnin
 ## Accessing project data
 
 The project datasets are mounted under `/hopsfs` in the Ray containers, so you can access `data.csv` from the `Resources` dataset using `/hopsfs/Resources/data.csv`.
+Shared datasets are accessible at `/hopsfs/shared-datasets/<source-project>/<dataset-name>` if HopsFS is mounted.


### PR DESCRIPTION
Add the mounted shared-dataset path to the Accessing project data sections in the Python notebook, Ray notebook, Python job, notebook job, and Ray job guides.

The new docs clarify that when HopsFS is mounted, shared datasets are available under /hopsfs/shared-datasets/<source-project>/<dataset-name>, alongside the existing examples for project-local datasets under /hopsfs.