### PR TITLE
[HWORKS-2762] User account level environment variables

### DIFF
--- a/docs/user_guides/mlops/serving/deployment.md
+++ b/docs/user_guides/mlops/serving/deployment.md
@@ -88,6 +88,16 @@ Optionally, you can access and adjust other parameters of the deployment configu
 You will be redirected to a full-page deployment creation form, where you can review all default configuration values and customize them to fit your requirements.
 In addition to the basic settings, this form allows you to further configure the [Predictor](#predictor) and [Transformer](#transformer) KServe components of your model deployment.
 
+The form includes *Predictor environment variables* and *Transformer environment variables* sections. The predictor section is pre-filled with your account-level [Environment variables][account-env-vars]; values you change in the form become per-deployment overrides for that specific deployment, and account-level values for names you don't include continue to apply at runtime.
+
+!!! info "Account-level variables also apply"
+    Variables defined under [Account settings → Environment variables][account-env-vars]
+    are injected into every model deployment you start. A value set on the
+    deployment overrides the account-level value with the same name for that
+    deployment only.
+
+[account-env-vars]: ../../projects/env_vars/create.md
+
 Once you are done with the changes, click on `Create new deployment` at the bottom of the page to create the deployment for your model.
 
 ### Step 4: Deployment creation

--- a/docs/user_guides/projects/env_vars/create.md
+++ b/docs/user_guides/projects/env_vars/create.md
@@ -75,6 +75,7 @@ variables**.
 ```python
 import hopsworks
 
+
 hopsworks.login()
 api = hopsworks.get_env_vars_api()
 
@@ -85,8 +86,8 @@ api.create_env_var("OPENAI_API_KEY", "sk-...")
 api.set_env_var("HF_TOKEN", "hf_...")
 
 # Read
-api.get("OPENAI_API_KEY")              # -> "sk-..." or None
-api.get_env_var("OPENAI_API_KEY")      # -> EnvVar object or None
+api.get("OPENAI_API_KEY")  # -> "sk-..." or None
+api.get_env_var("OPENAI_API_KEY")  # -> EnvVar object or None
 
 # List
 for v in api.get_env_vars():

--- a/docs/user_guides/projects/env_vars/create.md
+++ b/docs/user_guides/projects/env_vars/create.md
@@ -1,0 +1,119 @@
+# Account-level Environment Variables
+
+## Introduction
+
+Account-level environment variables are user-scoped, encrypted `name=value` pairs
+that Hopsworks injects into every runtime you start in any project where you
+are an active member:
+
+- Jobs (Python, Spark, Ray)
+- Jupyter notebooks
+- Streamlit / Python apps
+- Model deployments (KServe, sklearn, TensorFlow, Python predictors)
+- Python / agent serving
+- Terminal pods
+
+Values are encrypted at rest with the same mechanism as project [Secrets][secrets].
+A user can store up to 64 account-level variables; names must match
+`^[A-Za-z_][A-Za-z0-9_]*$` and must not collide with platform-reserved names
+such as `API_KEY`, `MATERIAL_DIRECTORY`, `PROJECT_ID`, or any name starting with
+`HOPS_`, `HOPSWORKS_`, or `HOPSFS_`.
+
+## Precedence
+
+Environment variables resolve in this order, **highest first**:
+
+1. **Per-execution** variables passed at run time
+   (`Execution.run_env_vars`) where supported.
+2. **Per-runtime** variables supplied at create or update time
+   (`Job.envVars`, deployment `predictor_env_vars` / `transformer_env_vars`,
+   app `env_vars`).
+3. **Account-level** variables defined here.
+4. Platform-injected image / runtime defaults (protected by the reserved-name
+   list at validation time).
+
+In other words: a value defined for a specific job, deployment, or app
+**always overrides** the account-level value with the same name for that one
+runtime. To clear an account-level value for a single run, set it to an empty
+string at the runtime level.
+
+## UI
+
+### Step 1: Open Account settings
+
+Click your avatar in the top right of Hopsworks and choose **Account settings**.
+
+### Step 2: Open the Environment variables tab
+
+In **Account settings**, click the **Environment variables** tab. You'll see a
+list of your existing variables, one per row.
+
+### Step 3: Add a variable
+
+Type a `NAME` and a `value` in the trailing empty row, then click the green
+checkmark to save. The value is hidden by default if the name contains
+`key` or `token` (case-insensitive); for those rows an eye icon toggles
+visibility. All other names render as plain text.
+
+To **edit** a value, change it inline and click the checkmark again. To
+**remove** one, click the trash icon.
+
+### Pre-fill in New Job / New Deployment / New App
+
+When you create a new Job, Deployment, or App, the **Environment variables**
+section in those dialogs is pre-filled with your account-level variables so
+you can see exactly what will be injected. Any value you change in those
+dialogs becomes a per-runtime override (precedence #2 above) for that one
+runtime; deleting a row from the dialog sends an empty value as a per-runtime
+override, effectively clearing the account-level value for that runtime only.
+
+To remove a variable everywhere, delete it from **Account settings → Environment
+variables**.
+
+## Python SDK
+
+```python
+import hopsworks
+
+hopsworks.login()
+api = hopsworks.get_env_vars_api()
+
+# Add
+api.create_env_var("OPENAI_API_KEY", "sk-...")
+
+# Add or update (idempotent — safe in setup scripts)
+api.set_env_var("HF_TOKEN", "hf_...")
+
+# Read
+api.get("OPENAI_API_KEY")              # -> "sk-..." or None
+api.get_env_var("OPENAI_API_KEY")      # -> EnvVar object or None
+
+# List
+for v in api.get_env_vars():
+    print(v.name)
+
+# Update
+api.update_env_var("OPENAI_API_KEY", "sk-new")
+
+# Remove
+api.delete_env_var("OPENAI_API_KEY")
+
+# Remove all
+api.delete_all()
+```
+
+`get_env_var` and `get` return `None` for missing names instead of raising,
+so they're convenient for "set if missing" patterns. `delete_env_var` raises
+`RestAPIError` with `ENV_VAR_NOT_FOUND` if the name doesn't exist.
+
+## Notes
+
+- Account-level variables are **per-user**. They are never shared with other
+  users in your project — to share configuration with project members, use
+  project-scoped [Secrets][secrets] instead.
+- Removing yourself from a project does **not** remove these variables; they
+  follow your account, not your project membership.
+- Values are encrypted at rest, mirroring Secrets. They are not exposed in
+  audit logs or error messages.
+
+[secrets]: ../secrets/create_secret.md

--- a/docs/user_guides/projects/env_vars/create.md
+++ b/docs/user_guides/projects/env_vars/create.md
@@ -2,9 +2,7 @@
 
 ## Introduction
 
-Account-level environment variables are user-scoped, encrypted `name=value` pairs
-that Hopsworks injects into every runtime you start in any project where you
-are an active member:
+Account-level environment variables are user-scoped, encrypted `name=value` pairs that Hopsworks injects into every runtime you start in any project where you are an active member:
 
 - Jobs (Python, Spark, Ray)
 - Jupyter notebooks
@@ -13,29 +11,21 @@ are an active member:
 - Python / agent serving
 - Terminal pods
 
-Values are encrypted at rest with the same mechanism as project [Secrets][secrets].
-A user can store up to 64 account-level variables; names must match
-`^[A-Za-z_][A-Za-z0-9_]*$` and must not collide with platform-reserved names
-such as `API_KEY`, `MATERIAL_DIRECTORY`, `PROJECT_ID`, or any name starting with
-`HOPS_`, `HOPSWORKS_`, or `HOPSFS_`.
+Values are encrypted at rest with the same mechanism as project [Secrets][how-to-create-a-secret].
+A user can store up to 64 account-level variables.
+Names must match `^[A-Za-z_][A-Za-z0-9_]*$` and must not collide with platform-reserved names such as `API_KEY`, `MATERIAL_DIRECTORY`, `PROJECT_ID`, or any name starting with `HOPS_`, `HOPSWORKS_`, or `HOPSFS_`.
 
 ## Precedence
 
 Environment variables resolve in this order, **highest first**:
 
-1. **Per-execution** variables passed at run time
-   (`Execution.run_env_vars`) where supported.
-2. **Per-runtime** variables supplied at create or update time
-   (`Job.envVars`, deployment `predictor_env_vars` / `transformer_env_vars`,
-   app `env_vars`).
+1. **Per-execution** variables passed at run time (`Execution.run_env_vars`) where supported.
+2. **Per-runtime** variables supplied at create or update time (`Job.envVars`, deployment `predictor_env_vars` / `transformer_env_vars`, app `env_vars`).
 3. **Account-level** variables defined here.
-4. Platform-injected image / runtime defaults (protected by the reserved-name
-   list at validation time).
+4. Platform-injected image / runtime defaults (protected by the reserved-name list at validation time).
 
-In other words: a value defined for a specific job, deployment, or app
-**always overrides** the account-level value with the same name for that one
-runtime. To clear an account-level value for a single run, set it to an empty
-string at the runtime level.
+A value defined for a specific job, deployment, or app **always overrides** the account-level value with the same name for that one runtime.
+To clear an account-level value for a single run, set it to an empty string at the runtime level.
 
 ## UI
 
@@ -45,30 +35,25 @@ Click your avatar in the top right of Hopsworks and choose **Account settings**.
 
 ### Step 2: Open the Environment variables tab
 
-In **Account settings**, click the **Environment variables** tab. You'll see a
-list of your existing variables, one per row.
+In **Account settings**, click the **Environment variables** tab.
+You'll see a list of your existing variables, one per row.
 
 ### Step 3: Add a variable
 
-Type a `NAME` and a `value` in the trailing empty row, then click the green
-checkmark to save. The value is hidden by default if the name contains
-`key` or `token` (case-insensitive); for those rows an eye icon toggles
-visibility. All other names render as plain text.
+Type a `NAME` and a `value` in the trailing empty row, then click the green checkmark to save.
+The value is hidden by default if the name contains `key` or `token` (case-insensitive); for those rows an eye icon toggles visibility.
+All other names render as plain text.
 
-To **edit** a value, change it inline and click the checkmark again. To
-**remove** one, click the trash icon.
+To **edit** a value, change it inline and click the checkmark again.
+To **remove** one, click the trash icon.
 
 ### Pre-fill in New Job / New Deployment / New App
 
-When you create a new Job, Deployment, or App, the **Environment variables**
-section in those dialogs is pre-filled with your account-level variables so
-you can see exactly what will be injected. Any value you change in those
-dialogs becomes a per-runtime override (precedence #2 above) for that one
-runtime; deleting a row from the dialog sends an empty value as a per-runtime
-override, effectively clearing the account-level value for that runtime only.
+When you create a new Job, Deployment, or App, the **Environment variables** section in those dialogs is pre-filled with your account-level variables so you can see exactly what will be injected.
+Any value you change in those dialogs becomes a per-runtime override (precedence #2 above) for that one runtime.
+Deleting a row from the dialog sends an empty value as a per-runtime override, effectively clearing the account-level value for that runtime only.
 
-To remove a variable everywhere, delete it from **Account settings → Environment
-variables**.
+To remove a variable everywhere, delete it from **Account settings → Environment variables**.
 
 ## Python SDK
 
@@ -103,18 +88,13 @@ api.delete_env_var("OPENAI_API_KEY")
 api.delete_all()
 ```
 
-`get_env_var` and `get` return `None` for missing names instead of raising,
-so they're convenient for "set if missing" patterns. `delete_env_var` raises
-`RestAPIError` with `ENV_VAR_NOT_FOUND` if the name doesn't exist.
+`get_env_var` and `get` return `None` for missing names instead of raising, so they're convenient for "set if missing" patterns.
+`delete_env_var` raises `RestAPIError` with `ENV_VAR_NOT_FOUND` if the name doesn't exist.
 
 ## Notes
 
-- Account-level variables are **per-user**. They are never shared with other
-  users in your project — to share configuration with project members, use
-  project-scoped [Secrets][secrets] instead.
-- Removing yourself from a project does **not** remove these variables; they
-  follow your account, not your project membership.
-- Values are encrypted at rest, mirroring Secrets. They are not exposed in
-  audit logs or error messages.
-
-[secrets]: ../secrets/create_secret.md
+- Account-level variables are **per-user**.
+  They are never shared with other users in your project — to share configuration with project members, use project-scoped [Secrets][how-to-create-a-secret] instead.
+- Removing yourself from a project does **not** remove these variables; they follow your account, not your project membership.
+- Values are encrypted at rest, mirroring Secrets.
+  They are not exposed in audit logs or error messages.

--- a/docs/user_guides/projects/index.md
+++ b/docs/user_guides/projects/index.md
@@ -12,3 +12,4 @@ This section serves to provide guides and examples for the common usage of servi
 - [Kafka](kafka/create_topic.md)
 - [OpenSearch](opensearch/connect.md)
 - [Secrets](secrets/create_secret.md)
+- [Environment Variables](env_vars/create.md)

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -29,11 +29,8 @@ For a manual (non-scheduled) run, these variables are only set if you explicitly
     If you set `HOPS_START_TIME` or `HOPS_END_TIME` in the job's envVars (or at launch time), your value wins over the scheduler-computed one for that execution. This is how backfill runs override the cron-derived interval.
 
 !!! info "Account-level variables also apply"
-    Variables defined under [Account settings → Environment variables][account-env-vars]
-    are also injected into every execution. A value set on the job overrides
-    the account-level value with the same name for this job only.
-
-[account-env-vars]: ../env_vars/create.md
+    Variables defined under [Account settings → Environment variables][account-level-environment-variables] are also injected into every execution.
+    A value set on the job overrides the account-level value with the same name for this job only.
 
 ## Incremental (recurring)
 

--- a/docs/user_guides/projects/jobs/batch_feature_pipeline.md
+++ b/docs/user_guides/projects/jobs/batch_feature_pipeline.md
@@ -28,6 +28,13 @@ For a manual (non-scheduled) run, these variables are only set if you explicitly
 !!! tip "User-defined env vars override the scheduler"
     If you set `HOPS_START_TIME` or `HOPS_END_TIME` in the job's envVars (or at launch time), your value wins over the scheduler-computed one for that execution. This is how backfill runs override the cron-derived interval.
 
+!!! info "Account-level variables also apply"
+    Variables defined under [Account settings → Environment variables][account-env-vars]
+    are also injected into every execution. A value set on the job overrides
+    the account-level value with the same name for this job only.
+
+[account-env-vars]: ../env_vars/create.md
+
 ## Incremental (recurring)
 
 Create or edit a job and configure its schedule under **Advanced scheduling**. Typical settings for a batch feature pipeline:

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -220,11 +220,8 @@ User-defined environment variables can be attached to a Python job under the
 `KEY=VALUE` pair that is set on the container for every execution of the job.
 
 !!! info "Account-level variables also apply"
-    Variables defined under [Account settings → Environment variables][account-env-vars]
-    are also injected into this job. A value set on the job overrides the
-    account-level value with the same name for this job only.
-
-[account-env-vars]: ../env_vars/create.md
+    Variables defined under [Account settings → Environment variables][account-level-environment-variables] are also injected into this job.
+    A value set on the job overrides the account-level value with the same name for this job only.
 
 ```python
 # inside your Python job script

--- a/docs/user_guides/projects/jobs/python_job.md
+++ b/docs/user_guides/projects/jobs/python_job.md
@@ -219,6 +219,13 @@ User-defined environment variables can be attached to a Python job under the
 *Environment variables* panel of the advanced configuration. Each entry is a
 `KEY=VALUE` pair that is set on the container for every execution of the job.
 
+!!! info "Account-level variables also apply"
+    Variables defined under [Account settings → Environment variables][account-env-vars]
+    are also injected into this job. A value set on the job overrides the
+    account-level value with the same name for this job only.
+
+[account-env-vars]: ../env_vars/create.md
+
 ```python
 # inside your Python job script
 import os

--- a/docs/user_guides/projects/jobs/spark_job.md
+++ b/docs/user_guides/projects/jobs/spark_job.md
@@ -279,11 +279,8 @@ User-defined environment variables can be attached to a Spark job under the
 of the job.
 
 !!! info "Account-level variables also apply"
-    Variables defined under [Account settings → Environment variables][account-env-vars]
-    are also injected into the Spark driver and executors. A value set on the
-    job overrides the account-level value with the same name for this job only.
-
-[account-env-vars]: ../env_vars/create.md
+    Variables defined under [Account settings → Environment variables][account-level-environment-variables] are also injected into the Spark driver and executors.
+    A value set on the job overrides the account-level value with the same name for this job only.
 
 ```python
 import os

--- a/docs/user_guides/projects/jobs/spark_job.md
+++ b/docs/user_guides/projects/jobs/spark_job.md
@@ -278,6 +278,13 @@ User-defined environment variables can be attached to a Spark job under the
 `KEY=VALUE` pair that is set on the Spark driver container for every execution
 of the job.
 
+!!! info "Account-level variables also apply"
+    Variables defined under [Account settings → Environment variables][account-env-vars]
+    are also injected into the Spark driver and executors. A value set on the
+    job overrides the account-level value with the same name for this job only.
+
+[account-env-vars]: ../env_vars/create.md
+
 ```python
 import os
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -92,11 +92,8 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
 </p>
 
 !!! info "Account-level environment variables"
-    Variables defined under [Account settings → Environment variables][account-env-vars]
-    are injected into every Jupyter session you start. Read them in your
-    notebook with `os.environ["MY_KEY"]`.
-
-[account-env-vars]: ../env_vars/create.md
+    Variables defined under [Account settings → Environment variables][account-level-environment-variables] are injected into every Jupyter session you start.
+    Read them in your notebook with `os.environ["MY_KEY"]`.
 
 ## Accessing project data
 

--- a/docs/user_guides/projects/jupyter/python_notebook.md
+++ b/docs/user_guides/projects/jupyter/python_notebook.md
@@ -91,6 +91,13 @@ Start the Jupyter instance by clicking the `Run Jupyter` button.
   </figure>
 </p>
 
+!!! info "Account-level environment variables"
+    Variables defined under [Account settings → Environment variables][account-env-vars]
+    are injected into every Jupyter session you start. Read them in your
+    notebook with `os.environ["MY_KEY"]`.
+
+[account-env-vars]: ../env_vars/create.md
+
 ## Accessing project data
 
 !!! notice "Recommended approach if `/hopsfs` is mounted"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,8 @@ nav:
               - Repository Actions: user_guides/projects/git/repository_actions.md
           - Secrets:
               - Create Secret: user_guides/projects/secrets/create_secret.md
+          - Environment variables:
+              - Account-level Environment Variables: user_guides/projects/env_vars/create.md
           - Api Keys:
               - Create API Key: user_guides/projects/api_key/create_api_key.md
           - AWS IAM Roles: user_guides/projects/iam_role/iam_role_chaining.md


### PR DESCRIPTION
## Summary

Documents the new account-level environment variables feature.

- New page `docs/user_guides/projects/env_vars/create.md` covering UI flow, Python SDK, and the reserved-name list.
- Precedence is documented end-to-end (per-execution > per-runtime > account > platform defaults).
- Cross-links added from python_job, spark_job, batch_feature_pipeline, model deployment, and jupyter/python_notebook.
- Wired into the side nav under **Projects → Environment variables**.

## Test plan
- [ ] \`mkdocs serve\` and verify the new page renders under Projects → Environment variables.
- [ ] Confirm the cross-link admonitions render correctly on the linked runtime pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)