### PR TITLE
[HWORKS-2796] Refresh Python 3.12

### DIFF
--- a/docs/user_guides/projects/python/python_env_overview.md
+++ b/docs/user_guides/projects/python/python_env_overview.md
@@ -28,7 +28,7 @@ Environments listed under `FEATURE ENGINEERING` corresponds to environments you 
 </p>
 
 !!! note "Python version"
-    The python version used in all the environments is 3.11.
+    The python version used in all the environments is 3.12.
 
 ### Feature engineering
 


### PR DESCRIPTION
## Summary

Track the HWORKS-2796 docker-images upgrade in user guide prose:

- \`docs/user_guides/projects/python/python_env_overview.md\` — "The python version used in all the environments" 3.11 → 3.12 (the feature-engineering / model-training / model-inference env families all moved in this upgrade; terminal-gpu is out of scope for this overview — it's a terminal env, not a pipeline env, and uses Python 3.13 via uv venv).
- \`docs/user_guides/mlops/serving/predictor.md\` — vLLM image-version example tag \`v0.14.0\` → \`v0.20.0\` to match the new helm-chart default.

Negative findings (not changed):
- \`docs/user_guides/client_installation/index.md\` SDK supported Python range \`3.10–3.13\` is accurate as-is (covers the new 3.12 default).
- The 35 mentions of base-image short-names across docs describe image *roles*, not specific Python/CUDA versions — no change needed.

Sibling PRs in [docker-images](https://github.com/logicalclocks/docker-images/pull/835), hopsworks-helm, hopsworks-ee, hopsworks-front, hopsworks-api, loadtest.

## Test plan

- [ ] \`touch docs/javadoc; uv run mkdocs build -s; rm docs/javadoc\` clean
- [ ] \`npx markdownlint-cli2 "**/*.md"\` clean (or no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)