### PR TITLE
[HWORKS-2813] Backend override for vllm-omni serve command to work with v0.20 arg-ordering

### DIFF
--- a/docs/user_guides/mlops/serving/predictor.md
+++ b/docs/user_guides/mlops/serving/predictor.md
@@ -364,7 +364,7 @@ Both the `VLLM` and `VLLM_OMNI` variants run the official upstream vLLM images p
 
 ### Image version
 
-The image version is the runtime image tag (for example `v0.14.0`) used for the vLLM container.
+The image version is the runtime image tag (for example `v0.20.0`) used for the vLLM container.
 If not set, Hopsworks picks the **highest** image version advertised for the chosen variant at creation time.
 Set it explicitly to pin a deployment to a specific image — useful when you need a stable, reproducible runtime.
 


### PR DESCRIPTION
## Summary

Bump the vLLM image-version example tag in `docs/user_guides/mlops/serving/predictor.md` from v0.14.0 → v0.20.0 to match the new helm defaults landing in [HWORKS-2813] hopsworks-helm.

Single-line user-guide refresh — no behavioral implications.

Sibling [HWORKS-2813] PRs in: hopsworks-helm, hopsworks-ee, hopsworks-api, hopsworks-front, docker-images, loadtest.

## Test plan

- [ ] Docs build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[HWORKS-2813]: https://hopsworks.atlassian.net/browse/HWORKS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-2813]: https://hopsworks.atlassian.net/browse/HWORKS-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ