### PR TITLE
[HWORKS-2814] Update WebSocket proxy docs for the Tyrus-based proxy

### DIFF
--- a/docs/setup_installation/admin/monitoring/websocket-pool.md
+++ b/docs/setup_installation/admin/monitoring/websocket-pool.md
@@ -21,7 +21,7 @@ The pod saturates at `maxSessionsPerApp` concurrent connections, which defaults 
 Unlike the previous proxy, there is no two-threads-per-connection accounting: the cap is a direct count of open sessions, not a derived thread number.
 
 There is no queue.
-Once a pod is at the cap, the next upgrade is closed immediately with a WebSocket `1013 TRY_AGAIN_LATER` close, and the platform surfaces a "Maximum number of WebSocket connections reached" error rather than blocking the user on a connection that will never attach.
+Once a pod is at the cap, the next upgrade is closed immediately with a WebSocket `1013 TRY_AGAIN_LATER` close whose reason string is `WebSocket session cap reached (maxSessionsPerApp)`, rather than blocking the user on a connection that will never attach.
 Rejecting cleanly protects the pod from connection-driven memory growth.
 
 ## Grafana panels
@@ -33,7 +33,7 @@ All read directly from metrics emitted by Payara on the `hopsworks-instance` pod
   Any non-zero value means at least one user was turned away from a Jupyter, terminal, or Streamlit session in the last minute.
   This is the alertable signal for "the cap is too low."
 
-- **WebSocket - duration (sliding-window percentiles)** plots p50, p95, and p99 of the duration of WebSocket connections after they close.
+- **WebSocket - duration (sliding window percentiles)** plots p50, p95, and p99 of the duration of WebSocket connections after they close.
   Values come from an exponentially-decaying sample reservoir with a roughly five-minute half-life, so closed long-lived sessions decay out of the percentiles quickly rather than dominating them forever.
 
 - **WebSocket - sessions** plots the current open-connection count per `hopsworks-instance` pod as solid lines, plus a single dashed red `Pool max (per instance)` line that shows the per-pod saturation point.

--- a/docs/setup_installation/admin/monitoring/websocket-pool.md
+++ b/docs/setup_installation/admin/monitoring/websocket-pool.md
@@ -32,6 +32,7 @@ All read directly from metrics emitted by Payara on the `hopsworks-instance` pod
 - **WebSocket - rejection rate** plots `sum(rate(ws_connection_rejections_total[1m]))`.
   Any non-zero value means at least one user was turned away from a Jupyter, terminal, or Streamlit session in the last minute.
   This is the alertable signal for "the cap is too low."
+  This counter covers cap-reached rejections only; a connection that is refused because its upstream pod is unreachable is counted separately under `ws_upstream_connect_failures_total` (see the metrics table), so this signal stays a clean measure of saturation.
 
 - **WebSocket - duration (sliding window percentiles)** plots p50, p95, and p99 of the duration of WebSocket connections after they close.
   Values come from an exponentially-decaying sample reservoir with a roughly five-minute half-life, so closed long-lived sessions decay out of the percentiles quickly rather than dominating them forever.
@@ -63,6 +64,7 @@ The metric names are unchanged from the previous proxy implementation, so existi
 | `ws_connection_in_flight_max_age_seconds` | gauge | Age, in seconds, of the oldest currently open connection. |
 | `ws_pool_max_connections` | gauge | Configured saturation point for one pod: the `maxSessionsPerApp` cap above which new upgrades are rejected with `1013 TRY_AGAIN_LATER`. |
 | `ws_connection_rejections_total` | counter | Cumulative count of connections rejected because the cap was reached. |
+| `ws_upstream_connect_failures_total` | counter | Cumulative count of sessions closed because the proxy could not reach the upstream (the kernel, shell, or app pod is not accepting connections). Distinct from `ws_connection_rejections_total` even though both close the browser with `1013 TRY_AGAIN_LATER`: this one means "the upstream is not up", not "the pod is saturated". |
 | `ws_connection_duration_seconds` | summary | Count, sum, max, mean, and quantile values for the duration of closed connections, in seconds. |
 | `ws_pool_cpu_cores` | gauge | CPU cores currently in use by the proxy's shared client transport threads. Computed from per-thread `ThreadMXBean.getThreadCpuTime` deltas divided by wall-clock dt; `1.0` means one full CPU core. `0` if the JVM does not support per-thread CPU accounting or on the first scrape after startup. |
 | `ws_pool_alloc_bytes_per_second` | gauge | Heap allocation rate, in bytes per second, summed over the proxy's client transport threads. Computed from per-thread `getThreadAllocatedBytes` deltas divided by wall dt. This is GC pressure produced by the forwarding work, not the memory it currently holds; per-thread heap residency is not measurable through standard `ThreadMXBean` APIs. `0` on JVMs without `com.sun.management.ThreadMXBean`. |

--- a/docs/setup_installation/admin/monitoring/websocket-pool.md
+++ b/docs/setup_installation/admin/monitoring/websocket-pool.md
@@ -2,27 +2,27 @@
 
 ## Introduction
 
-Jupyter, terminal, RStudio, Streamlit, the Ray dashboard, and the Spark driver UI are reached through Hopsworks by way of a WebSocket-aware HTTP proxy.
-Every WebSocket connection that flows through that proxy holds two threads in a single managed executor pool on Payara, named `concurrent/websocketsExecutorService`, for the full lifetime of the connection.
-When the pool fills, new connections are rejected and the user-facing component (for example, JupyterLab) cannot reach its kernel.
+Jupyter, terminals, and Streamlit apps are reached through Hopsworks by way of a WebSocket-aware proxy on the `hopsworks-instance` pods.
+Each browser WebSocket that flows through that proxy is bridged to its upstream (the kernel, shell, or app pod) for the full lifetime of the connection, and every open bridge counts as one session against a per-pod cap.
+When a pod reaches that cap, the next upgrade is rejected and the user-facing component (for example, JupyterLab) cannot reach its kernel.
 
-This page describes how to monitor the pool through Grafana, how to read the metrics that the platform exposes, and how to tune the pool from the Helm chart when the cluster has more concurrent notebook users than the defaults can serve.
-The same pool drives the user-visible capacity badges described in [Session Capacity Warnings][session-capacity-warnings]; admin tuning here shifts the threshold those badges report against.
+This page describes how to monitor the proxy through Grafana, how to read the metrics that the platform exposes, and how to tune the cap from the Helm chart when the cluster has more concurrent notebook users than the defaults can serve.
+The same counts drive the user-visible capacity badges described in [Session Capacity Warnings][session-capacity-warnings]; admin tuning here shifts the threshold those badges report against.
 
 ## Prerequisites
 
 To access the Grafana dashboards described here, follow [Services Dashboards](./grafana.md) and confirm that you can open the `Hopsworks` dashboard under the `Hops` folder.
-To change pool sizing or Grizzly timeouts, you need to be able to edit the Helm values file used to install the chart and run `helm upgrade`.
+To change the session cap or the proxy buffers, you need to be able to edit the Helm values file used to install the chart and run `helm upgrade`.
 
-## How the pool relates to concurrent users
+## How the cap relates to concurrent users
 
-Each WebSocket connection consumes two threads in `concurrent/websocketsExecutorService` (one per stream direction).
-The pool therefore saturates at `maximumPoolSize / 2` concurrent connections.
-At the default sizing — `corePoolSize: 100`, `maximumPoolSize: 200`, `taskQueueCapacity: 0` — that is 100 concurrent WebSocket connections.
+Each open browser WebSocket the proxy is bridging counts as one in-flight session, and all three WebSocket-backed components — Jupyter kernels, terminals, and Streamlit apps — draw from the same per-pod budget.
+The pod saturates at `maxSessionsPerApp` concurrent connections, which defaults to `800`.
+Unlike the previous proxy, there is no two-threads-per-connection accounting: the cap is a direct count of open sessions, not a derived thread number.
 
-The task queue is intentionally zero-length.
-Threads in this pool are long-lived (often hours, in the case of an open notebook), so a queue would only let users keep clicking _Connect_ on a kernel that never actually attaches.
-Once the pool is full, the platform surfaces a "Maximum number of WebSocket connections reached" error on the next attempted connection rather than blocking the user indefinitely.
+There is no queue.
+Once a pod is at the cap, the next upgrade is closed immediately with a WebSocket `1013 TRY_AGAIN_LATER` close, and the platform surfaces a "Maximum number of WebSocket connections reached" error rather than blocking the user on a connection that will never attach.
+Rejecting cleanly protects the pod from connection-driven memory growth.
 
 ## Grafana panels
 
@@ -31,7 +31,7 @@ All read directly from metrics emitted by Payara on the `hopsworks-instance` pod
 
 - **WebSocket - rejection rate** plots `sum(rate(ws_connection_rejections_total[1m]))`.
   Any non-zero value means at least one user was turned away from a Jupyter, terminal, or Streamlit session in the last minute.
-  This is the alertable signal for "the pool is too small."
+  This is the alertable signal for "the cap is too low."
 
 - **WebSocket - duration (sliding-window percentiles)** plots p50, p95, and p99 of the duration of WebSocket connections after they close.
   Values come from an exponentially-decaying sample reservoir with a roughly five-minute half-life, so closed long-lived sessions decay out of the percentiles quickly rather than dominating them forever.
@@ -40,12 +40,12 @@ All read directly from metrics emitted by Payara on the `hopsworks-instance` pod
   A pod whose solid line meets the dashed line is rejecting new sessions.
 
 - **WebSocket - pool CPU** plots `ws_pool_cpu_cores` per pod, in CPU cores.
-  A value of `1.0` means the pool is consuming one full CPU core on that pod.
+  A value of `1.0` means the proxy's forwarding threads are consuming one full CPU core on that pod.
   Compare against the pod's CPU request or limit to judge whether to scale the pod's CPU allocation up.
 
 - **WebSocket - pool allocation rate (GC pressure)** plots `ws_pool_alloc_bytes_per_second` per pod.
   This is heap allocation rate, not residency.
-  A high rate means the pool is producing garbage, which translates to GC pressure on the JVM; it does not mean the pool is holding that much memory.
+  A high rate means the forwarding threads are producing garbage, which translates to GC pressure on the JVM; it does not mean the proxy is holding that much memory.
   For "is the JVM heap getting full?" use the `Memory` panel above; for "is the pod approaching its k8s memory limit?" use the Kubernetes / Pods dashboard.
 
 The per-pod panels carry the pod short identifier in the legend (the `<replicaset-hash>-<pod-hash>` tail; the `hopsworks-instance-` prefix is stripped because every series on this dashboard comes from an instance pod by construction).
@@ -55,55 +55,53 @@ The per-pod panels carry the pod short identifier in the legend (the `<replicase
 The metrics are emitted on the standard Payara MicroProfile Metrics endpoint (`/metrics`) under the `application` scope.
 They are scraped by the in-cluster Prometheus server alongside the other Hopsworks service metrics, so federation and `remote_write` (see [Exporting Hopsworks metrics](./export-metrics.md)) cover them automatically.
 
+The metric names are unchanged from the previous proxy implementation, so existing dashboards and alerts keep working; only the data source moved.
+
 | Metric | Type | Meaning |
 | --- | --- | --- |
-| `ws_connection_in_flight_count` | gauge | Currently open WebSocket connections. Derived from the executor's `getActiveCount` divided by two so it reflects orphan pump threads from rejected half-success connections, not only the in-process session map. |
+| `ws_connection_in_flight_count` | gauge | Inbound WebSocket sessions currently open on this pod, one per browser leg the proxy is bridging. Tracked directly from the bridge's session open/close, not derived from a thread count. |
 | `ws_connection_in_flight_max_age_seconds` | gauge | Age, in seconds, of the oldest currently open connection. |
-| `ws_pool_max_connections` | gauge | Configured saturation point for one pod: `maximumPoolSize / 2`. Reported as `-1` if Payara internals could not be introspected at startup. |
-| `ws_connection_rejections_total` | counter | Cumulative count of connections rejected because the pool was full. |
+| `ws_pool_max_connections` | gauge | Configured saturation point for one pod: the `maxSessionsPerApp` cap above which new upgrades are rejected with `1013 TRY_AGAIN_LATER`. |
+| `ws_connection_rejections_total` | counter | Cumulative count of connections rejected because the cap was reached. |
 | `ws_connection_duration_seconds` | summary | Count, sum, max, mean, and quantile values for the duration of closed connections, in seconds. |
-| `ws_pool_cpu_cores` | gauge | CPU cores currently in use by the pool. Computed from per-thread `ThreadMXBean.getThreadCpuTime` deltas divided by wall-clock dt; `1.0` means one full CPU core. `0` if the JVM does not support per-thread CPU accounting or on the first scrape after startup. |
-| `ws_pool_alloc_bytes_per_second` | gauge | Heap allocation rate, in bytes per second, summed over alive pool threads. Computed from per-thread `getThreadAllocatedBytes` deltas divided by wall dt. This is GC pressure produced by the pool, not the memory it currently holds; per-thread heap residency is not measurable through standard `ThreadMXBean` APIs. `0` on JVMs without `com.sun.management.ThreadMXBean`. |
+| `ws_pool_cpu_cores` | gauge | CPU cores currently in use by the proxy's shared client transport threads. Computed from per-thread `ThreadMXBean.getThreadCpuTime` deltas divided by wall-clock dt; `1.0` means one full CPU core. `0` if the JVM does not support per-thread CPU accounting or on the first scrape after startup. |
+| `ws_pool_alloc_bytes_per_second` | gauge | Heap allocation rate, in bytes per second, summed over the proxy's client transport threads. Computed from per-thread `getThreadAllocatedBytes` deltas divided by wall dt. This is GC pressure produced by the forwarding work, not the memory it currently holds; per-thread heap residency is not measurable through standard `ThreadMXBean` APIs. `0` on JVMs without `com.sun.management.ThreadMXBean`. |
 
 All metrics carry the standard Kubernetes pod labels added by Prometheus during scraping (`pod_name`, `namespace`, `node`).
 Dashboard queries that need to disambiguate per-pod series rewrite `pod_name` to a `pod_short` label that drops the `hopsworks-instance-` prefix.
 Cluster-wide aggregates (`sum()`, `max()`) collapse pod labels and present one line per metric.
 
-## Tuning the pool
+## Tuning the proxy
 
-The pool is configured at install time through `values.yaml`:
+The proxy is configured at install time through `values.yaml`:
 
 ```yaml
 hopsworks:
   payara:
-    executorService:
-      websockets:
-        corePoolSize: 100      # threads kept alive
-        maximumPoolSize: 200   # hard ceiling = 2x maxConcurrentConnections
-        taskQueueCapacity: 0   # do not queue; reject when full
-        threadPriority: 8      # above default so pumps are not starved
+    websocketProxy:
+      maxSessionsPerApp: 800        # concurrent inbound WS sessions per pod
+      incomingBufferBytes: 33554432 # max single received frame, in bytes (32 MiB)
+      grizzlyWorkerPoolMaxSize: 200 # cap on the shared client transport workers
+      sessionIdleTimeoutMs: 0       # 0 = no idle reaper (sessions are long-lived)
 ```
 
-Bump `corePoolSize` and `maximumPoolSize` together.
-`maximumPoolSize` must remain twice the number of concurrent WebSocket connections you want to serve, because of the two-threads-per-connection rule.
-Leave `taskQueueCapacity` at `0`.
-A non-zero queue with this workload causes users to wait on connections that will never become active threads; rejection is the safer behavior.
+Raise `maxSessionsPerApp` to serve more concurrent notebook, terminal, and Streamlit users per pod.
+The cap is a direct connection count, so the value is the number of concurrent connections you want each pod to serve — there is no longer a factor-of-two thread conversion.
 
-Each thread is otherwise idle (it blocks on stream I/O), so the dominant resource cost of raising these numbers is JVM thread overhead in `hopsworks-instance` pods.
-A few hundred extra threads add a few tens of megabytes of stack memory at `-Xss512k`, which is small relative to the Payara JVM heap.
-After changing the sizing, watch four panels on the `Hopsworks` dashboard:
+The dominant resource cost of raising the cap is the memory held by the in-flight connections and the CPU spent forwarding their traffic, not thread overhead.
+`grizzlyWorkerPoolMaxSize` bounds the shared client transport worker pool that carries the upstream-to-browser leg; leave it at the default unless the CPU panel shows the transport starved.
+`incomingBufferBytes` is the ceiling a single received WebSocket frame (for example, a large Jupyter cell output) must fit under; it is grown on demand rather than pre-allocated, and should stay at or above Jupyter's iopub rate-limit budget.
+
+After changing the cap, watch four panels on the `Hopsworks` dashboard:
 
 - **Memory**: confirm the `Used heap` line stays comfortably below the dashed `Max heap (-Xmx)` line after each GC.
-- **WebSocket - pool CPU**: confirm the pool's CPU draw stays below the pod's CPU request or limit.
+- **WebSocket - pool CPU**: confirm the proxy's CPU draw stays below the pod's CPU request or limit.
 - **WebSocket - pool allocation rate (GC pressure)**: check whether the higher session count is producing enough allocation to drive GC time up.
 - **GC**: confirm GC time stays within budget after the allocation rate moves.
 
 For pod-vs-Kubernetes-limit context (working set vs request and limit) see the `Kubernetes / Pods` dashboard.
 
-## Grizzly timeouts
+## Idle connections
 
-The chart leaves Payara / Grizzly `request-timeout-seconds` and `websockets-timeout-seconds` at their defaults.
-The first governs the HTTP request lifecycle (the Upgrade handshake through the 101 response); once a WebSocket is established the framing layer takes over, where `websockets-timeout-seconds` is the idle timer.
-A WebSocket session that sits idle past that default closes; JupyterLab and the terminal client both reconnect transparently, and the kernel / shell / Streamlit process running in its own pod is unaffected by the disconnect.
-
-If your users need a longer idle window, raise `network-config.protocols.protocol.http-listener-2.http.websockets-timeout-seconds` via a post-boot `asadmin` override or a future chart value — that attribute (note the plural) is what governs the established-WebSocket idle clock on Payara 6.
+By default `sessionIdleTimeoutMs` is `0`, which disables the proxy's idle reaper: proxied sessions are legitimately long-lived (an open notebook can sit idle for hours), so the proxy does not close them on inactivity.
+Set a positive value (in milliseconds) only if you want the proxy itself to drop idle connections; JupyterLab and the terminal client both reconnect transparently after such a close, and the kernel, shell, or Streamlit process running in its own pod is unaffected by the disconnect.

--- a/docs/user_guides/projects/jupyter/session_capacity_warnings.md
+++ b/docs/user_guides/projects/jupyter/session_capacity_warnings.md
@@ -41,7 +41,8 @@ On a single-instance deployment the two badges always agree, since the only inst
 - `Run Jupyter`, `Start Terminal`, and per-row `Start App` buttons are disabled while the **cluster** badge is red (no instance has capacity to serve a new session).
   While only the instance badge is red the buttons stay enabled because refreshing or signing back in may land you on a different instance pod that still has capacity.
 - An already-running Jupyter server keeps working.
-  Opening a new notebook tab inside a running Jupyter server may still fail with a `WebSocket pool full` error if the proxy slot the new tab needs is unavailable.
+  Opening a new notebook tab inside a running Jupyter server may still fail if the pod that hosts it is at its per-session cap: the new tab's kernel WebSocket upgrade is closed with a `1013 TRY_AGAIN_LATER` close rather than attaching.
+  This is distinct from starting a new session (a Jupyter server, terminal, or Streamlit app), which is gated up front and rejected with a `WebSocket pool full` (HTTP 503) error when the pod has no free slot.
 - An already-running terminal session keeps working.
   Reconnecting after a network blip while the badge is red surfaces the error rather than silently retrying.
 

--- a/docs/user_guides/projects/jupyter/session_capacity_warnings.md
+++ b/docs/user_guides/projects/jupyter/session_capacity_warnings.md
@@ -53,12 +53,13 @@ On a single-instance deployment the two badges always agree, since the only inst
 - **Red on the instance badge, orange or no cluster badge**: a different pod has capacity.
   Refresh the page or sign out and back in to land on a different instance pod.
 - **Red on both badges**: the platform is at capacity.
-  Wait for active sessions to time out (the default WebSocket idle timeout is 30 minutes), close notebook tabs you are no longer using, or contact your administrator about raising the platform's pool sizing.
+  Close notebook tabs, terminals, and apps you are no longer using to free sessions, or contact your administrator about raising the platform's session cap.
+  By default the proxy does not reap idle sessions, so a slot is only released when its connection actually closes.
 
 ## Why the limits exist
 
-Each WebSocket session (a Jupyter kernel connection, a terminal connection, or a Streamlit app connection) occupies two threads in a dedicated pool inside the Hopsworks instance.
-The pool is sized so the platform can stay responsive when many users are active at once.
+Each WebSocket session (a Jupyter kernel connection, a terminal connection, or a Streamlit app connection) counts as one open connection against a per-pod cap inside the Hopsworks instance.
+The cap is sized so the platform can stay responsive when many users are active at once.
 Letting new sessions queue indefinitely would leave users staring at a loading spinner that never resolves; rejecting cleanly with the badge is the safer behavior.
 
 Administrators can change the pool sizing per cluster.


### PR DESCRIPTION
Docs side of HWORKS-2814 (Membrane → Tyrus WebSocket proxy). Pairs with hopsworks-ee #3065 / helm #1967.

The HWORKS-2682 docs described the Membrane-era model (every connection held two threads in `concurrent/websocketsExecutorService`, saturation at `maximumPoolSize / 2`, tuning via `payara.executorService.websockets.*`). After HWORKS-2814 the proxy is Tyrus-based and the metrics are re-sourced from it — **metric names unchanged, so Grafana panels/alerts are untouched**. Updates both docs to the current model:

- In-flight is a direct count of open inbound sessions (not `getActiveCount / 2`).
- The cap is `maxSessionsPerApp` (default 800) — a connection count with no factor-of-two thread conversion; overflow closes with `1013 TRY_AGAIN_LATER`.
- Tuning moved to `payara.websocketProxy.*` (`maxSessionsPerApp`, `incomingBufferBytes`, `grizzlyWorkerPoolMaxSize`, `sessionIdleTimeoutMs`).

Files: `admin/monitoring/websocket-pool.md`, `projects/jupyter/session_capacity_warnings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
