### PR TITLE
[HWORKS-2851] Add Agents docs

### DIFF
--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -198,7 +198,7 @@ in a project creates them automatically if they do not already exist.
 After that, choose one of these storage modes:
 
 - `online` - the default; writes traces to only online
-- `offline` - writes traces to only offline. You will no be able to see the traces summaries in the UI, but you can 
+- `offline` - writes traces to only offline. You will no be able to see the traces summaries in the UI, but you can
   use the hopsworks-api to read the offline feature groups and reconstruct the traces from there.
 - `both` - export traces to both online and offline feature groups. This is the recommended option for production deployments, as it allows you to see the traces in the UI and also have them stored cost-effectively for long-term retention.
 

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -68,7 +68,7 @@ can inspect its status, logs, endpoints, and configuration.
 
 ## Small example
 
-The file below shows a compact agent program that uses LlamaIndex, FastAPI,
+The file below shows a simple agent program that uses LlamaIndex, FastAPI,
 and OpenTelemetry.
 
 Set `ANTHROPIC_API_KEY` in the deployment environment. Hopsworks injects the

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -1,0 +1,205 @@
+---
+description: Documentation on how to configure and run an Agent Deployment on Hopsworks.
+---
+
+# How To Run An Agent Deployment
+
+## Introduction
+
+Agent Deployments are **server-only KServe deployments with no model attached**.
+You ship an entry script or package that exposes a predictor, and Hopsworks
+serves it behind an endpoint. Use Agent Deployments for interactive agents and
+LLM workflows, where the service needs to stay up and answer requests.
+
+If you need a fire-and-forget background run, use [Agent Tasks](../tasks/index.md)
+instead.
+
+Common use cases:
+
+- **Interactive assistants** - a chat or tool-using agent that stays online
+- **LLM workflows** - a deterministic sequence of retrieval, reasoning, and
+  generation steps that you want to expose as a service
+- **RAG-backed services** - an agent that reads Feature Store context and uses
+  it to answer questions
+
+## Where to find it in the UI
+
+In the project sidebar, go to **Agents** and then **Agent Deployments**.
+The list page shows the agent deployments in the project, along with the same
+type of detail page you use for model deployments.
+
+## Create and manage an agent deployment
+
+The most common way to create one is with the SDK or the CLI:
+
+```bash
+hops agent list
+hops agent create my_agent.py --name my_agent --requirements requirements.txt --environment my_agent
+hops agent start my_agent
+hops agent query my_agent --data '{"prompt": "hello"}'
+hops agent logs my_agent
+hops agent info my_agent
+hops agent stop my_agent
+hops agent delete my_agent --yes
+```
+
+Use `hops agent list` first to confirm auth and serving are reachable.
+
+```python
+import hopsworks
+
+project = hopsworks.login()
+ms = project.get_model_serving()
+
+deployment = ms.deploy_agent(
+    entry="my_agent.py",                 # .py file or a dir with pyproject.toml
+    name="my_agent",
+    requirements="requirements.txt",
+    environment="my_agent",
+    upload_dir="Resources/agents",       # default
+)
+deployment.start(await_running=600)
+print(deployment.predict(inputs={"prompt": "hello"}))
+# After editing the code: re-create, then deployment.restart()
+```
+
+After creation, the deployment appears in the Agent Deployments list where you
+can inspect its status, logs, endpoints, and configuration.
+
+## Small example
+
+The file below shows a compact agent program that uses LlamaIndex, FastAPI,
+and OpenTelemetry. The FastAPI app is there for local smoke testing; the same
+agent logic can live in your Hopsworks deployment entry file.
+
+Set `OPENAI_API_KEY` in the deployment environment. Hopsworks injects the
+`OTEL_EXPORTER_OTLP_*` environment variables for the deployment, so the
+OpenTelemetry exporter can stay configuration-free.
+
+```python
+import asyncio
+import os
+
+from fastapi import FastAPI
+from llama_index.core.agent.workflow import ReActAgent
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.openai import OpenAI
+from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+import uvicorn
+
+def add(a: float, b: float) -> float:
+    """Adds two numbers."""
+    return a + b
+
+
+def subtract(a: float, b: float) -> float:
+    """Subtracts two numbers."""
+    return a - b
+
+
+def multiply(a: float, b: float) -> float:
+    """Multiplies two numbers."""
+    return a * b
+
+
+def divide(a: float, b: float) -> float:
+    """Divides two numbers."""
+    if b == 0:
+        raise ValueError("Cannot divide by zero.")
+    return a / b
+
+
+def build_tracer_provider():
+    endpoint = os.environ.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces"
+    )
+    tracer_provider = trace_sdk.TracerProvider()
+    tracer_provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+    )
+    return tracer_provider
+
+
+class AgentPredictor:
+    def __init__(self):
+        self.tracer_provider = build_tracer_provider()
+        LlamaIndexInstrumentor().instrument(tracer_provider=self.tracer_provider)
+
+        llm = OpenAI(model="gpt-4o-mini")
+        tools = [
+            FunctionTool.from_defaults(add),
+            FunctionTool.from_defaults(subtract),
+            FunctionTool.from_defaults(multiply),
+            FunctionTool.from_defaults(divide),
+        ]
+        self.agent = ReActAgent(tools=tools, llm=llm)
+
+    async def _predict_async(self, inputs):
+        prompt = inputs.get("prompt", "")
+        result = await self.agent.run(prompt)
+        return {"answer": str(result)}
+
+    def predict(self, inputs):
+        return asyncio.run(self._predict_async(inputs))
+
+
+predictor = AgentPredictor()
+agent_app = FastAPI()
+FastAPIInstrumentor.instrument_app(agent_app, tracer_provider=predictor.tracer_provider)
+
+
+@agent_app.post("/query")
+def query(payload: dict):
+    return predictor.predict(payload)
+
+
+if __name__ == "__main__":
+    uvicorn.run(agent_app, host="0.0.0.0", port=8080)
+```
+
+Example dependencies:
+
+```text
+llama-index-core
+llama-index-llms-openai
+fastapi
+uvicorn
+openinference-instrumentation-llama-index
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
+opentelemetry-instrumentation-fastapi
+```
+
+## Tracing
+
+Agent Deployments can be configured with OpenTelemetry tracing.
+
+When tracing is enabled, Hopsworks automatically provisions four online,
+Delta-backed feature groups in the project's Feature Store:
+
+- `otel_spans` - root spans and trace summary fields
+- `otel_span_attributes` - span attributes as key-value pairs
+- `otel_events` - span events
+- `otel_event_attributes` - event attributes as key-value pairs
+
+The Traces UI reads from these feature groups, and the first traced deployment
+in a project creates them automatically if they do not already exist.
+
+After that, choose one of these storage modes:
+
+- `online` - the default; writes traces to only online
+- `offline` - writes traces to only offline. You will no be able to see the traces summaries in the UI, but you can 
+  use the hopsworks-api to read the offline feature groups and reconstruct the traces from there.
+- `both` - export traces to both online and offline feature groups. This is the recommended option for production deployments, as it allows you to see the traces in the UI and also have them stored cost-effectively for long-term retention.
+
+## Next steps
+
+- Scheduled, non-interactive coding agent: [Agent Tasks](../tasks/index.md)
+- Model-backed online predictor: use the Model Deployments guides under MLOps
+- Agent-serving dependencies: see the environment guides for cloning Python
+  environments and installing requirements

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -52,11 +52,11 @@ project = hopsworks.login()
 ms = project.get_model_serving()
 
 deployment = ms.deploy_agent(
-    entry="my_agent.py",                 # .py file or a dir with pyproject.toml
+    entry="my_agent.py",  # .py file or a dir with pyproject.toml
     name="my_agent",
     requirements="requirements.txt",
     environment="my_agent",
-    upload_dir="Resources/agents",       # default
+    upload_dir="Resources/agents",  # default
 )
 deployment.start(await_running=600)
 print(deployment.predict(inputs={"prompt": "hello"}))
@@ -79,6 +79,7 @@ OpenTelemetry exporter can stay configuration-free.
 import asyncio
 import os
 
+import uvicorn
 from fastapi import FastAPI
 from llama_index.core.agent.workflow import ReActAgent
 from llama_index.core.tools import FunctionTool
@@ -88,77 +89,74 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-import uvicorn
 
 
 def add(a: float, b: float) -> float:
-  """Adds two numbers."""
-  return a + b
+    """Adds two numbers."""
+    return a + b
 
 
 def subtract(a: float, b: float) -> float:
-  """Subtracts two numbers."""
-  return a - b
+    """Subtracts two numbers."""
+    return a - b
 
 
 def multiply(a: float, b: float) -> float:
-  """Multiplies two numbers."""
-  return a * b
+    """Multiplies two numbers."""
+    return a * b
 
 
 def divide(a: float, b: float) -> float:
-  """Divides two numbers."""
-  if b == 0:
-    raise ValueError("Cannot divide by zero.")
-  return a / b
+    """Divides two numbers."""
+    if b == 0:
+        raise ValueError("Cannot divide by zero.")
+    return a / b
 
 
 def build_tracer_provider():
-  endpoint = os.environ.get(
-    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-    "http://localhost:4318/v1/traces",
-  )
+    endpoint = os.environ.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "http://localhost:4318/v1/traces",
+    )
 
-  tracer_provider = trace_sdk.TracerProvider()
-  tracer_provider.add_span_processor(
-    SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
-  )
-  return tracer_provider
+    tracer_provider = trace_sdk.TracerProvider()
+    tracer_provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+    )
+    return tracer_provider
 
 
 class AgentPredictor:
-  def __init__(self):
-    self.tracer_provider = build_tracer_provider()
+    def __init__(self):
+        self.tracer_provider = build_tracer_provider()
 
-    LlamaIndexInstrumentor().instrument(
-      tracer_provider=self.tracer_provider
-    )
+        LlamaIndexInstrumentor().instrument(tracer_provider=self.tracer_provider)
 
-    llm = Anthropic(
-      model="claude-haiku-4-5-20251001",
-      max_tokens=1024,
-      temperature=0.0,
-    )
+        llm = Anthropic(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1024,
+            temperature=0.0,
+        )
 
-    tools = [
-      FunctionTool.from_defaults(add),
-      FunctionTool.from_defaults(subtract),
-      FunctionTool.from_defaults(multiply),
-      FunctionTool.from_defaults(divide),
-    ]
+        tools = [
+            FunctionTool.from_defaults(add),
+            FunctionTool.from_defaults(subtract),
+            FunctionTool.from_defaults(multiply),
+            FunctionTool.from_defaults(divide),
+        ]
 
-    self.agent = ReActAgent(
-      tools=tools,
-      llm=llm,
-    )
+        self.agent = ReActAgent(
+            tools=tools,
+            llm=llm,
+        )
 
-  async def _predict_async(self, inputs):
-    prompt = inputs.get("prompt", "")
-    result = await self.agent.run(prompt)
-    return {"answer": str(result)}
+    async def _predict_async(self, inputs):
+        prompt = inputs.get("prompt", "")
+        result = await self.agent.run(prompt)
+        return {"answer": str(result)}
 
-  def predict(self, inputs):
-    return asyncio.run(self._predict_async(inputs))
+    def predict(self, inputs):
+        return asyncio.run(self._predict_async(inputs))
 
 
 predictor = AgentPredictor()
@@ -166,18 +164,18 @@ predictor = AgentPredictor()
 agent_app = FastAPI()
 
 FastAPIInstrumentor.instrument_app(
-  agent_app,
-  tracer_provider=predictor.tracer_provider,
+    agent_app,
+    tracer_provider=predictor.tracer_provider,
 )
 
 
 @agent_app.post("/query")
 def query(payload: dict):
-  return predictor.predict(payload)
+    return predictor.predict(payload)
 
 
 if __name__ == "__main__":
-  uvicorn.run(agent_app, host="0.0.0.0", port=8080)
+    uvicorn.run(agent_app, host="0.0.0.0", port=8080)
 ```
 
 ## Tracing

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -47,7 +47,6 @@ Use `hops agent list` first to confirm auth and serving are reachable.
 
 ```python
 import hopsworks
-
 project = hopsworks.login()
 ms = project.get_model_serving()
 

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -72,7 +72,7 @@ The file below shows a compact agent program that uses LlamaIndex, FastAPI,
 and OpenTelemetry. The FastAPI app is there for local smoke testing; the same
 agent logic can live in your Hopsworks deployment entry file.
 
-Set `OPENAI_API_KEY` in the deployment environment. Hopsworks injects the
+Set `ANTHROPIC_API_KEY` in the deployment environment. Hopsworks injects the
 `OTEL_EXPORTER_OTLP_*` environment variables for the deployment, so the
 OpenTelemetry exporter can stay configuration-free.
 
@@ -83,7 +83,7 @@ import os
 from fastapi import FastAPI
 from llama_index.core.agent.workflow import ReActAgent
 from llama_index.core.tools import FunctionTool
-from llama_index.llms.openai import OpenAI
+from llama_index.llms.anthropic import Anthropic
 from openinference.instrumentation.llama_index import LlamaIndexInstrumentor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -91,74 +91,94 @@ from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 import uvicorn
 
+
 def add(a: float, b: float) -> float:
-    """Adds two numbers."""
-    return a + b
+  """Adds two numbers."""
+  return a + b
 
 
 def subtract(a: float, b: float) -> float:
-    """Subtracts two numbers."""
-    return a - b
+  """Subtracts two numbers."""
+  return a - b
 
 
 def multiply(a: float, b: float) -> float:
-    """Multiplies two numbers."""
-    return a * b
+  """Multiplies two numbers."""
+  return a * b
 
 
 def divide(a: float, b: float) -> float:
-    """Divides two numbers."""
-    if b == 0:
-        raise ValueError("Cannot divide by zero.")
-    return a / b
+  """Divides two numbers."""
+  if b == 0:
+    raise ValueError("Cannot divide by zero.")
+  return a / b
 
 
 def build_tracer_provider():
-    endpoint = os.environ.get(
-        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://localhost:4318/v1/traces"
-    )
-    tracer_provider = trace_sdk.TracerProvider()
-    tracer_provider.add_span_processor(
-        SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
-    )
-    return tracer_provider
+  endpoint = os.environ.get(
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "http://localhost:4318/v1/traces",
+  )
+
+  tracer_provider = trace_sdk.TracerProvider()
+  tracer_provider.add_span_processor(
+    SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+  )
+  return tracer_provider
 
 
 class AgentPredictor:
-    def __init__(self):
-        self.tracer_provider = build_tracer_provider()
-        LlamaIndexInstrumentor().instrument(tracer_provider=self.tracer_provider)
+  def __init__(self):
+    self.tracer_provider = build_tracer_provider()
 
-        llm = OpenAI(model="gpt-4o-mini")
-        tools = [
-            FunctionTool.from_defaults(add),
-            FunctionTool.from_defaults(subtract),
-            FunctionTool.from_defaults(multiply),
-            FunctionTool.from_defaults(divide),
-        ]
-        self.agent = ReActAgent(tools=tools, llm=llm)
+    LlamaIndexInstrumentor().instrument(
+      tracer_provider=self.tracer_provider
+    )
 
-    async def _predict_async(self, inputs):
-        prompt = inputs.get("prompt", "")
-        result = await self.agent.run(prompt)
-        return {"answer": str(result)}
+    llm = Anthropic(
+      model="claude-haiku-4-5-20251001",
+      max_tokens=1024,
+      temperature=0.0,
+    )
 
-    def predict(self, inputs):
-        return asyncio.run(self._predict_async(inputs))
+    tools = [
+      FunctionTool.from_defaults(add),
+      FunctionTool.from_defaults(subtract),
+      FunctionTool.from_defaults(multiply),
+      FunctionTool.from_defaults(divide),
+    ]
+
+    self.agent = ReActAgent(
+      tools=tools,
+      llm=llm,
+    )
+
+  async def _predict_async(self, inputs):
+    prompt = inputs.get("prompt", "")
+    result = await self.agent.run(prompt)
+    return {"answer": str(result)}
+
+  def predict(self, inputs):
+    return asyncio.run(self._predict_async(inputs))
 
 
 predictor = AgentPredictor()
+
 agent_app = FastAPI()
-FastAPIInstrumentor.instrument_app(agent_app, tracer_provider=predictor.tracer_provider)
+
+FastAPIInstrumentor.instrument_app(
+  agent_app,
+  tracer_provider=predictor.tracer_provider,
+)
 
 
 @agent_app.post("/query")
 def query(payload: dict):
-    return predictor.predict(payload)
+  return predictor.predict(payload)
 
 
 if __name__ == "__main__":
-    uvicorn.run(agent_app, host="0.0.0.0", port=8080)
+  uvicorn.run(agent_app, host="0.0.0.0", port=8080)
 ```
 
 Example dependencies:

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -69,8 +69,7 @@ can inspect its status, logs, endpoints, and configuration.
 ## Small example
 
 The file below shows a compact agent program that uses LlamaIndex, FastAPI,
-and OpenTelemetry. The FastAPI app is there for local smoke testing; the same
-agent logic can live in your Hopsworks deployment entry file.
+and OpenTelemetry.
 
 Set `ANTHROPIC_API_KEY` in the deployment environment. Hopsworks injects the
 `OTEL_EXPORTER_OTLP_*` environment variables for the deployment, so the
@@ -179,20 +178,6 @@ def query(payload: dict):
 
 if __name__ == "__main__":
   uvicorn.run(agent_app, host="0.0.0.0", port=8080)
-```
-
-Example dependencies:
-
-```text
-llama-index-core
-llama-index-llms-openai
-fastapi
-uvicorn
-openinference-instrumentation-llama-index
-opentelemetry-api
-opentelemetry-sdk
-opentelemetry-exporter-otlp-proto-http
-opentelemetry-instrumentation-fastapi
 ```
 
 ## Tracing

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -47,6 +47,8 @@ Use `hops agent list` first to confirm auth and serving are reachable.
 
 ```python
 import hopsworks
+
+
 project = hopsworks.login()
 ms = project.get_model_serving()
 

--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -7,9 +7,10 @@ description: Documentation on how to configure and run an Agent Deployment on Ho
 ## Introduction
 
 Agent Deployments are **server-only KServe deployments with no model attached**.
-You ship an entry script or package that exposes a predictor, and Hopsworks
-serves it behind an endpoint. Use Agent Deployments for interactive agents and
-LLM workflows, where the service needs to stay up and answer requests.
+You provide an entrypoint Python script that starts a REST server.
+Hopsworks exposes it behind an endpoint.
+Use Agent Deployments for interactive agents and LLM workflows.
+The service needs to stay up and answer requests.
 
 If you need a fire-and-forget background run, use [Agent Tasks](../tasks/index.md)
 instead.

--- a/docs/user_guides/agents/index.md
+++ b/docs/user_guides/agents/index.md
@@ -1,0 +1,6 @@
+# Agents
+
+This section serves to provide guides and examples for the common usage of agent tasks and agent deployments through the Hopsworks UI and APIs.
+
+- [Agent Tasks](tasks/index.md): Fire-and-forget agent executions that run as first-class Hopsworks jobs.
+- [Agent Deployments](deployments/index.md): Served interactive agents and LLM workflows.

--- a/docs/user_guides/agents/tasks/index.md
+++ b/docs/user_guides/agents/tasks/index.md
@@ -1,62 +1,62 @@
 ---
-description: Documentation on how to configure and execute an Agent Job on Hopsworks.
+description: Documentation on how to configure and execute an Agent Task on Hopsworks.
 ---
 
-# How To Run An Agent Job
+# How To Run An Agent Task
 
 ## Introduction
 
-Agent Jobs are **fire-and-forget AI agents** that run as first-class Hopsworks jobs.
+Agent Tasks are **fire-and-forget AI agents** that run as first-class Hopsworks jobs.
 You write a prompt, select a provider (Claude Code or OpenAI Codex), grant the
 agent a set of permissions, point it at the project resources it needs, and
 launch it.
 The agent runs to completion inside a Kubernetes pod, writes its results to
 HopsFS, and the pod terminates.
-No interactive UI, no WebSocket — the same lifecycle as a Python or Spark job.
+No interactive UI, no WebSocket - the same lifecycle as a Python or Spark job.
 
 Common use cases:
 
-- **Scheduled data-quality audits** — point the agent at a Feature Group and ask
+- **Scheduled data-quality audits** - point the agent at a Feature Group and ask
   it to look for null spikes, schema drift, or freshness issues each night
-- **Model evaluation** — give it a Model + Deployment ref and have it grade
+- **Model evaluation** - give it a Model + Deployment ref and have it grade
   recent predictions against a reference dataset
-- **Operational runbooks** — turn the wiki page you'd hand a new on-call into a
+- **Operational runbooks** - turn the wiki page you'd hand a new on-call into a
   prompt the agent runs whenever a `LONG_RUNNING` alert fires on a pipeline
-- **Ad-hoc exploration** — fire one off from the CLI with `hops job start`
+- **Ad-hoc exploration** - fire one off from the CLI with `hops job start`
   whenever you'd otherwise open Jupyter for a one-shot question
 
-Because Agent Jobs use the existing Jobs subsystem, you get the same scheduling,
+Because Agent Tasks use the existing Jobs subsystem, you get the same scheduling,
 alerts, log capture, and execution history you do for any other Hopsworks job.
 
 ## Prerequisites
 
-1. **Feature flag** — agent jobs are gated cluster-wide. An admin must set:
+1. **Feature flag** - agent tasks are gated cluster-wide. An admin must set:
 
       ```sql
       UPDATE variables SET value='true' WHERE id='agent_jobs_enabled';
       ```
 
 2. **Authentication credentials** for whichever provider you choose. The agent
-    can pick these up from three sources (see [Authentication](#authentication)
-    below) — the simplest is to log in to Claude or Codex once from an
-    interactive Hopsworks Terminal session; the credentials persist into HopsFS
-    and every subsequent Agent Job in any of your projects reuses them.
+   can pick these up from three sources (see [Authentication](#authentication)
+   below) - the simplest is to log in to Claude or Codex once from an
+   interactive Hopsworks Terminal session; the credentials persist into HopsFS
+   and every subsequent Agent Task in any of your projects reuses them.
 
-3. **The `agent-job` Python environment** (or a clone of it) — this is the
-    runtime base image. It's installed by default; clone it in
-    Project Settings → Python Environments if you need to layer additional
-    libraries on top.
+3. **The `agent-job` Python environment** (or a clone of it) - this is the
+   runtime base image. It's installed by default; clone it in
+   Project Settings -> Python Environments if you need to layer additional
+   libraries on top.
 
 ## UI
 
-### Step 1: Open Jobs and create a new Agent Job
+### Step 1: Open Jobs and create a new Agent Task
 
 Click **Jobs** in the project sidebar, then **New Job**, and pick `AGENT` as the
 job type.
 
 ### Step 2: Write the prompt
 
-The prompt is the task description — what you want the agent to do.
+The prompt is the task description - what you want the agent to do.
 Be explicit about the inputs (which Feature Group, which Model) and the
 expected output (a report file at `${AGENT_OUTPUT_PATH}/result.md`, a Slack
 message, etc).
@@ -80,18 +80,18 @@ Codex-only fields (`cliArgs`) appear when you select Codex; Claude-only fields
 
 ### Step 4: Configure permissions
 
-Permissions are an explicit allowlist of tools the agent may invoke — they map
+Permissions are an explicit allowlist of tools the agent may invoke - they map
 directly to the underlying CLI's tool patterns. Pick a preset for most jobs:
 
 | Preset | Effect |
 | --- | --- |
-| `READ_ONLY` (default) | Inspect feature groups, feature views, models — no writes. |
+| `READ_ONLY` (default) | Inspect feature groups, feature views, models - no writes. |
 | `OPERATOR` | Run any `hops` CLI command + `python *`, plus write under `/hopsfs/*`. |
-| `FULL` | A curated allowlist of common shell commands (`ls`, `cat`, `grep`, `find`, `curl`, `wget`, `echo`, `mkdir`, `cp`, `mv`), plus `Read(*)` and `Write(/hopsfs/*)`. **Not** unrestricted shell access — pick **Custom** if you need that. |
+| `FULL` | A curated allowlist of common shell commands (`ls`, `cat`, `grep`, `find`, `curl`, `wget`, `echo`, `mkdir`, `cp`, `mv`), plus `Read(*)` and `Write(/hopsfs/*)`. **Not** unrestricted shell access - pick **Custom** if you need that. |
 | `Custom` | A list of patterns you provide explicitly (e.g. `Bash(hops fg info *)`, `Read(*)`, `Write(/hopsfs/Resources/*)`). |
 
 The agent runs with project-scoped JWT auth, so any data access still goes
-through normal Hopsworks ACLs — permissions just bound what the *agent* is
+through normal Hopsworks ACLs - permissions just bound what the *agent* is
 allowed to attempt.
 
 ### Step 5: Attach resource references (optional)
@@ -108,7 +108,7 @@ without you having to spell every detail out in the prompt:
 | `deployment` | no | `/context/deployment_<name>.json` |
 | `job` | no | `/context/job_<name>.json` |
 
-Refs are resolved server-side at launch time by the platform — you don't need
+Refs are resolved server-side at launch time by the platform - you don't need
 to write any glue code.
 
 ### Step 6: Environment variables (optional)
@@ -116,11 +116,11 @@ to write any glue code.
 Use this card to supply credentials and other env vars the agent needs at
 runtime. Vars set here are merged on top of:
 
-1. Platform-injected vars (project ID, JWT path, HopsFS user home, …) — these
-    are reserved and rejected if you try to set them
+1. Platform-injected vars (project ID, JWT path, HopsFS user home, ...) - these
+   are reserved and rejected if you try to set them
 2. AI-provider secrets (from your AI provider secrets table, if any)
-3. Your **account-level env vars** (visible across all your runtimes — manage
-    them under Account → Environment variables)
+3. Your **account-level env vars** (visible across all your runtimes - manage
+   them under Account -> Environment variables)
 
 So a per-job `ANTHROPIC_API_KEY` overrides the account-level value, which in
 turn overrides anything in the secrets table.
@@ -128,7 +128,7 @@ turn overrides anything in the secrets table.
 Reserved-name prefixes that you may **not** set: `HOPS_`, `HOPSWORKS_`,
 `HOPSFS_`, `AGENT_`.
 The platform injects several `AGENT_*` variables that you can *read* from
-your prompt — most usefully `AGENT_OUTPUT_PATH` (where your final
+your prompt - most usefully `AGENT_OUTPUT_PATH` (where your final
 artifact must be written). They are reserved for the platform, so you
 can't override them, but referencing them inside the prompt (e.g.
 `${AGENT_OUTPUT_PATH}/result.md`) is the intended pattern.
@@ -141,12 +141,12 @@ shared-datasets folder under `/hopsfs/`, so prompts can refer to it as
 
 The bottom of the form is shared with other job types:
 
-- **Environment** — defaults to `agent-job`. Pick a clone if you've added
+- **Environment** - defaults to `agent-job`. Pick a clone if you've added
   Python libraries on top.
-- **Resource configuration** — CPU cores, memory, GPU count. Default is 0.5
+- **Resource configuration** - CPU cores, memory, GPU count. Default is 0.5
   cores / 1024 MB / 0 GPU; bump this for heavier tasks.
-- **Schedule** — same as other jobs. Cron expressions or interval runs.
-- **Alerts** — FINISHED / FAILED / KILLED / LONG_RUNNING, routed to a Slack
+- **Schedule** - same as other jobs. Cron expressions or interval runs.
+- **Alerts** - FINISHED / FAILED / KILLED / LONG_RUNNING, routed to a Slack
   / webhook / email receiver. Setting `passToAgent: true` on a Slack alert
   injects `SLACK_WEBHOOK_URL` and `SLACK_CHANNEL` into the agent pod's env so
   the agent can post during execution via the bundled `slack-post` helper.
@@ -164,10 +164,10 @@ The agent pod resolves provider credentials in this priority order:
    in any of your projects and run `claude login` (or `codex login`), the
    credentials persist in HopsFS at `/hopsfs/Users/<you>/.claude/.credentials.json`
    and `/hopsfs/Users/<you>/.codex/auth.json`. The agent pod symlinks `~/.claude`
-   and `~/.codex` to those paths automatically — no API key needed.
+   and `~/.codex` to those paths automatically - no API key needed.
 2. **`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` from env.** If terminal credentials
    are missing or invalid, the agent falls back to these env vars. Set them
-   under Account → Environment variables (applies to all your jobs) or in this
+   under Account -> Environment variables (applies to all your jobs) or in this
    job's Environment variables section (applies just to this job).
 3. **AI provider secrets table.** If you've configured AI providers under
    Project Settings, those keys are also injected. Per-job env vars override
@@ -177,11 +177,11 @@ Most users only need to do step 1 once.
 
 ## CLI
 
-You can also create and run agent jobs via the `hops` CLI:
+You can also create and run agent tasks via the `hops` CLI:
 
 ```bash
 # Create from a JSON config
-cat > my-agent.json <<EOF
+cat > my-agent-task.json <<EOF
 {
   "type": "agentJobConfiguration",
   "appName": "data-quality-check",
@@ -198,7 +198,7 @@ cat > my-agent.json <<EOF
 }
 EOF
 
-hops job create -f my-agent.json
+hops job create -f my-agent-task.json
 hops job start data-quality-check
 hops job logs data-quality-check --tail
 ```
@@ -208,26 +208,26 @@ or query other jobs as long as you grant it `Bash(hops *)`.
 
 ## REST API
 
-Agent Jobs use the existing Jobs REST API; the only difference is the
+Agent Tasks use the existing Jobs REST API; the only difference is the
 configuration payload, where `type` is `"agentJobConfiguration"` and the
 fields are:
 
 | Field | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `type` | string | yes | — | Must be `"agentJobConfiguration"` |
-| `appName` | string | yes | — | Job name |
-| `prompt` | string | yes | — | The task |
+| `type` | string | yes | - | Must be `"agentJobConfiguration"` |
+| `appName` | string | yes | - | Job name |
+| `prompt` | string | yes | - | The task |
 | `provider` | string | no | `"claude"` | `"claude"` or `"codex"` |
-| `cliArgs` | string | no | — | Extra codex CLI flags (codex only) |
+| `cliArgs` | string | no | - | Extra codex CLI flags (codex only) |
 | `model` | string | no | `claude-sonnet-4-5` | Provider-specific model ID |
 | `maxTurns` | int | no | 50 | Claude only |
-| `maxBudgetUsd` | float | no | — | Claude only, max 100 |
+| `maxBudgetUsd` | float | no | - | Claude only, max 100 |
 | `permissionPreset` | string | no | `READ_ONLY` | `READ_ONLY` / `OPERATOR` / `FULL` |
-| `permissions` | string[] | no | — | Custom — overrides preset if set |
-| `refs` | AgentRef[] | no | — | Resource refs (see [Step 5](#step-5-attach-resource-references-optional)) |
-| `hooks` | AgentHook[] | no | — | Pre/post tool-use hooks (claude only) |
-| `skillsRef` | string | no | — | Path to a `.md` skills file on HopsFS |
-| `envVars` | string[] | no | — | `"KEY=VALUE"` strings |
+| `permissions` | string[] | no | - | Custom - overrides preset if set |
+| `refs` | AgentRef[] | no | - | Resource refs (see [Step 5](#step-5-attach-resource-references-optional)) |
+| `hooks` | AgentHook[] | no | - | Pre/post tool-use hooks (claude only) |
+| `skillsRef` | string | no | - | Path to a `.md` skills file on HopsFS |
+| `envVars` | string[] | no | - | `"KEY=VALUE"` strings |
 | `environmentName` | string | no | `agent-job` | Must be `agent-job` or a clone of it |
 | `resourceConfig` | object | no | default | `{ cores, memory, gpus }` |
 | `outputPath` | string | no | auto | Where to write results in HopsFS |
@@ -242,7 +242,7 @@ By default the agent writes to:
 
 ```text
 /hopsfs/Resources/jobs/<job-name>/<execution-id>/
-├── result.md         # primary, human-readable result — rendered by the UI
+├── result.md         # primary, human-readable result - rendered by the UI
 ├── metadata.json     # { "exit_code": 0, "completed_at": "<ISO8601>" }
 └── (any other files the agent chose to write)
 ```
@@ -252,12 +252,12 @@ visible via the Logs button on the execution row.
 
 ## Limitations
 
-- **Non-interactive only.** The agent cannot ask follow-up questions — the
+- **Non-interactive only.** The agent cannot ask follow-up questions - the
   prompt is the whole input. If you need interactive iteration, use a Terminal
   session instead.
-- **`maxTurns` is a hard safety net** (claude only) — set it high enough that
+- **`maxTurns` is a hard safety net** (claude only) - set it high enough that
   reasonable runs don't trip it. Default 50.
-- **The image must be `agent-job` or a clone** — other Python environments
+- **The image must be `agent-job` or a clone** - other Python environments
   don't ship the Claude/Codex CLIs and will be rejected at job-create time.
-- **Reserved env-var prefixes** — see [Step 6](#step-6-environment-variables-optional);
+- **Reserved env-var prefixes** - see [Step 6](#step-6-environment-variables-optional);
   `HOPS_`, `HOPSWORKS_`, `HOPSFS_`, and `AGENT_` are owned by the platform.

--- a/docs/user_guides/index.md
+++ b/docs/user_guides/index.md
@@ -6,6 +6,7 @@ This section serves to provide guides and examples for the common usage of abstr
 - [Feature Store](fs/index.md): Learn about the common usage of the core Hopsworks Feature Store abstractions, such as Feature Groups, Feature Views, Data Validation and Data Sources.
   Also, learn from the [Client Integrations](integrations/index.md) guides how to connect to the Feature Store from external environments such as a local Python environment, Databricks, or AWS Sagemaker
 - [MLOps](mlops/index.md): Learn about the common usage of Hopsworks MLOps abstractions, such as the Model Registry or Model Serving.
+- [Agents](agents/index.md): Learn about agent tasks and agent deployments in Hopsworks.
 - [Projects](projects/index.md): The core abstraction on Hopsworks are [Projects](../concepts/projects/governance.md).
   Learn in this section how to manage your projects and the services therein.
 - [Migration](migration/40_migration.md): Learn how to migrate to newer versions of Hopsworks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,7 +173,6 @@ nav:
               - Run PySpark Job: user_guides/projects/jobs/pyspark_job.md
               - Run Spark Job: user_guides/projects/jobs/spark_job.md
               - Run Ray Job: user_guides/projects/jobs/ray_job.md
-              - Run Agent Job: user_guides/projects/jobs/agent_job.md
               - Scheduling: user_guides/projects/jobs/schedule_job.md
               - Batch Feature Pipelines: user_guides/projects/jobs/batch_feature_pipeline.md
           - Kubernetes Scheduling:
@@ -241,6 +240,12 @@ nav:
               - External Access: user_guides/mlops/serving/external-access.md
           - Vector Database: user_guides/fs/vector_similarity_search.md
           - Provenance: user_guides/mlops/provenance/provenance.md
+      - Agents:
+          - user_guides/agents/index.md
+          - Agent Tasks:
+              - user_guides/agents/tasks/index.md
+          - Agent Deployments:
+              - user_guides/agents/deployments/index.md
       - Migration:
           - 3.X to 4.0: user_guides/migration/40_migration.md
   - Setup and Administration:


### PR DESCRIPTION
- Rename the top-level how-to section from Agent to Agents.
- Add a new Agents landing page with links to Agent Tasks and Agent Deployments.
- Move the former Agent Job guide into the new Agent Tasks page and update terminology throughout.
- Add a new Agent Deployments guide, including the minimal LlamaIndex/FastAPI/OTEL example and tracing feature-group notes.
- Remove the obsolete agent_job page now that the docs are not yet released.