### PR TITLE
[HWORKS-2852] Add Helm chart values reference and overhaul AWS getting started

### DIFF
--- a/.github/workflows/mkdocs-release.yml
+++ b/.github/workflows/mkdocs-release.yml
@@ -96,6 +96,29 @@ jobs:
       - name: Install Hopsworks Python API
         run: uv pip install hopsworks-api/python
 
+      - name: Generate Helm values reference
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          if [ "$BRANCH" = "main" ]; then
+            # dev docs: latest chart from the (private) dev channel. Skip (keep
+            # the page placeholder) when the Nexus credentials are absent rather
+            # than failing the build.
+            if [ -n "$NEXUS_USER" ]; then
+              hopsworks-docs gen-helm-values \
+                --repo-url https://nexus.hops.works/repository/hopsworks-helm-dev
+            else
+              echo "Nexus credentials not available; keeping the values reference placeholder."
+            fi
+          else
+            # release docs: latest patch of the chart version (major.minor) for this docs version.
+            # The released repo is public, so fetch anonymously (clear any creds).
+            NEXUS_USER= NEXUS_PASSWORD= hopsworks-docs gen-helm-values \
+              --repo-url https://nexus.hops.works/repository/hopsworks-helm \
+              --chart-version "$HOPSWORKS_VERSION"
+          fi
+
       - name: Install Ubuntu dependencies
         run: sudo apt update && sudo apt-get install -y libxml2-dev libxslt-dev
 

--- a/.github/workflows/mkdocs-test.yml
+++ b/.github/workflows/mkdocs-test.yml
@@ -43,6 +43,30 @@ jobs:
       - name: Snakeoil (Python code blocks in markdown)
         run: hopsworks-docs snakeoil
 
+      - name: Generate Helm values reference
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$BASE_REF" = "main" ]; then
+            # dev docs: latest chart from the (private) dev channel. Fork PRs do
+            # not receive secrets, so skip (keep the page placeholder) when the
+            # Nexus credentials are absent rather than failing the build.
+            if [ -n "$NEXUS_USER" ]; then
+              hopsworks-docs gen-helm-values \
+                --repo-url https://nexus.hops.works/repository/hopsworks-helm-dev
+            else
+              echo "Nexus credentials not available (e.g. a fork PR); keeping the values reference placeholder."
+            fi
+          else
+            # release docs: latest patch of the chart version (major.minor) for this docs version.
+            # The released repo is public, so fetch anonymously (clear any creds).
+            NEXUS_USER= NEXUS_PASSWORD= hopsworks-docs gen-helm-values \
+              --repo-url https://nexus.hops.works/repository/hopsworks-helm \
+              --chart-version "${BASE_REF#branch-}"
+          fi
+
       - name: Check mkdocs warnings
         run: hopsworks-docs check
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ uv python install 3.13
 # (`pyenv install 3.13` then `pyenv shell 3.13`) so uv resolves to the right interpreter.
 
 uv sync
-# Install hopsworks-api for gathering docstrings for the API reference
-uv pip install git+https://github.com/logicalclocks/hopsworks-api.git@main#subdirectory=python
+# Install hopsworks-api for gathering docstrings for the API reference.
+# The `[python]` extra is required: the hopsworks-apigen plugin dynamically
+# imports hsfs/hsml/hopsworks, and hsfs imports pyarrow at load time, so the
+# base install (without the extra) fails the build with ModuleNotFoundError.
+uv pip install "hopsworks[python] @ git+https://github.com/logicalclocks/hopsworks-api.git@main#subdirectory=python"
 ```
 
 Alternatively, you can just activate the virtual environment you use for development of `hopsworks-api` (obtained via `uv sync`), this is the way it is done in the actions.
@@ -86,6 +89,21 @@ uv run mike set-default latest
 
 The `mkdocs.yml` file of this repository defines the pages to show in the navigation.
 After adding your new page in the docs folder, you also need to add it to this file for it to show up in the navigation.
+
+## Helm chart values reference
+
+The `setup_installation/common/helm_chart_values.md` page renders a placeholder locally; its `## Values` table is injected at build time by the `hopsworks-docs gen-helm-values` step and is **never committed**.
+CI fetches the chart from Nexus rather than the (private) `hopsworks-helm` git repo: release builds (`branch-x.y`) read the public `hopsworks-helm` repo anonymously and pick the latest patch of the chart version matching the docs version, while the development build (`main`) reads the private `hopsworks-helm-dev` repo and uses its newest published chart.
+The development path requires the read-only `NEXUS_USER` and `NEXUS_PASSWORD` repository secrets; without them the `main` build's generation step fails.
+Older chart versions that predate the chart's `## Values` section keep the page placeholder (the build warns rather than failing).
+
+To preview the table locally against a chart checkout:
+
+```bash
+uv run --extra cli hopsworks-docs gen-helm-values --chart <path-to-hopsworks-helm>
+```
+
+This rewrites the page in place, so restore it (`git checkout docs/setup_installation/common/helm_chart_values.md`) before committing.
 
 ## Checking links
 

--- a/docs/setup_installation/aws/getting_started.md
+++ b/docs/setup_installation/aws/getting_started.md
@@ -1,54 +1,60 @@
-# AWS - Getting started
+# AWS - Getting started with EKS
 
-Kubernetes and Helm are used to install & run Hopsworks and the Feature Store
-in the cloud.
-They both integrate seamlessly with third-party platforms such as Databricks,
-SageMaker and KubeFlow.
-This guide shows how to set up the Hopsworks platform in your organization's AWS account.
+Kubernetes and Helm are used to install and run Hopsworks and the Feature Store in the cloud.
+They both integrate seamlessly with third-party platforms such as Databricks, SageMaker and Kubeflow.
+This guide shows how to set up the Hopsworks platform on Amazon EKS in your organization's AWS account.
 
 ## Prerequisites
 
-To follow the instruction on this page you will need the following:
+To follow the instructions on this page you will need the following:
 
-- Kubernetes Version: Hopsworks can be deployed on EKS clusters running Kubernetes >= 1.27.0.
-- [aws-cli](https://aws.amazon.com/cli/) to provision the AWS resources
-- [eksctl](https://eksctl.io/) to interact with the AWS APIs and provision the EKS cluster
-- [helm](https://helm.sh/) to deploy Hopsworks
-
-### ECR Registry
-
-Hopsworks allows users to customize the images used by Python jobs, Jupyter Notebooks and (Py)Spark applications running in their projects.
-The images are stored in ECR.
-Hopsworks needs access to an ECR repository to push the project images.
+- Kubernetes version: Hopsworks supports EKS clusters running Kubernetes >= 1.27.0 and < 1.35.0 (the chart's supported range, enforced by its `kubeVersion` constraint).
+  Pick a version in that range that is also under [AWS standard support](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html), for example 1.33.
+- [aws-cli](https://aws.amazon.com/cli/) to provision the AWS resources.
+- [eksctl](https://eksctl.io/) to create and manage the EKS cluster.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) to interact with the cluster.
+- [helm](https://helm.sh/) to deploy Hopsworks.
 
 ### Permissions
 
 - The deployment requires cluster admin access to create ClusterRoles, ServiceAccounts, and ClusterRoleBindings.
-
 - A namespace is required to deploy the Hopsworks stack.
-If you don’t have permissions to create a namespace, ask your EKS administrator to provision one.
+  If you don't have permissions to create a namespace, ask your EKS administrator to provision one.
 
-## EKS Deployment
+## Step 1: AWS EKS setup
 
-The following steps describe how to deploy an EKS cluster and related resources so that it’s compatible with Hopsworks.
+The following steps describe how to deploy an EKS cluster and the related resources so that it is compatible with Hopsworks.
 
-## Step 1: AWS EKS Setup
+### Step 1.1: Create an S3 bucket
 
-### Step 1.1: Create S3 Bucket
+Create a bucket to store project data.
 
 ```bash
 aws s3 mb s3://BUCKET_NAME --region REGION --profile PROFILE
 ```
 
-### Step 1.2: Create ECR Repository
+Enable versioning on the bucket.
+The RonDB and OpenSearch backups, and HopsFS, write to this bucket and rely on object versioning, so backups do not work correctly without it:
 
-Create the repository to host the projects images.
+```bash
+aws s3api put-bucket-versioning --bucket BUCKET_NAME --versioning-configuration Status=Enabled --profile PROFILE
+```
+
+### Step 1.2: Create an ECR repository
+
+Hopsworks allows users to customize the images used by Python jobs, Jupyter notebooks and (Py)Spark applications running in their projects.
+These images are stored in ECR, so Hopsworks needs access to an ECR repository to push the project images.
+
+Create the repository to host the project images:
 
 ```bash
 aws --profile PROFILE ecr create-repository --repository-name NAMESPACE/hopsworks-base --region REGION
 ```
 
-### Step 1.3: Create IAM Policies
+### Step 1.3: Create IAM policies
+
+Create a policy that grants access to the S3 bucket and the ECR repository.
+Save the following document as `policy.json`, replacing BUCKET_NAME, REGION, and ECR_AWS_ACCOUNT_ID with your values:
 
 ```json
 {
@@ -58,18 +64,18 @@ aws --profile PROFILE ecr create-repository --repository-name NAMESPACE/hopswork
       "Sid": "hopsworksaiInstanceProfile",
       "Effect": "Allow",
       "Action": [
-        "S3:PutObject",
-        "S3:ListBucket",
-        "S3:GetObject",
-        "S3:DeleteObject",
-        "S3:AbortMultipartUpload",
-        "S3:ListBucketMultipartUploads",
-        "S3:PutLifecycleConfiguration",
-        "S3:GetLifecycleConfiguration",
-        "S3:PutBucketVersioning",
-        "S3:GetBucketVersioning",
-        "S3:ListBucketVersions",
-        "S3:DeleteObjectVersion"
+        "s3:PutObject",
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListBucketMultipartUploads",
+        "s3:PutLifecycleConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketVersioning",
+        "s3:ListBucketVersions",
+        "s3:DeleteObjectVersion"
       ],
       "Resource": [
         "arn:aws:s3:::BUCKET_NAME/*",
@@ -101,19 +107,24 @@ aws --profile PROFILE ecr create-repository --repository-name NAMESPACE/hopswork
 }
 ```
 
+Create the policy:
+
 ```bash
 aws --profile PROFILE iam create-policy --policy-name POLICY_NAME --policy-document file://policy.json
 ```
 
-### Step 1.4: Create EKS cluster using eksctl
+This single policy grants both S3 (bucket) and ECR (repository) access.
+Because the Helm values do not store any S3 access keys, Hopsworks and HopsFS reach the bucket through the AWS default credential provider chain, which on EKS resolves to the worker node instance IAM role.
+Attaching this policy to the node group (Step 1.4) is therefore how Hopsworks is granted access to S3 and ECR — no access key or secret is stored in Kubernetes.
 
-When creating the cluster using eksctl the following parameters are required in the cluster configuration YAML file (eksctl.yaml):
+### Step 1.4: Create the EKS cluster using eksctl
 
-- amiFamily should either be AmazonLinux2023 or Ubuntu2404
+When creating the cluster with eksctl, the following are required in the cluster configuration file (`eksctl.yaml`):
 
-- Instance type should be Intel based or AMD (i.e not ARM)
-
-- The following policies are required: [IAM policies - eksctl](https://eksctl.io/usage/iam-policies/#attaching-policies-by-arn)
+- `amiFamily` should be either `AmazonLinux2023` or `Ubuntu2404`.
+  Amazon Linux 2 reaches end of support on June 30, 2026, so do not use it.
+- The instance type should be Intel or AMD based (that is, not ARM/Graviton).
+- The following managed policies are required (see [attaching policies by ARN](https://eksctl.io/usage/iam-policies/#attaching-policies-by-arn)):
 
 ```bash
 - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
@@ -121,14 +132,14 @@ When creating the cluster using eksctl the following parameters are required in 
 - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
 ```
 
-The following is required if you are using the EKS AWS Load Balancer Controller to grant permissions to the controller to provision the necessary load balancers [Welcome: AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)
+To let Hopsworks provision the necessary load balancers through the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/), grant the controller permissions by enabling the add-on policy on the node group:
 
 ```bash
       withAddonPolicies:
         awsLoadBalancerController: true
 ```
 
-You need to update the CLUSTER NAME and the POLICY ARN generated above
+Update CLUSTER_NAME, REGION, ECR_AWS_ACCOUNT_ID, and the policy name (POLICY_NAME) created above, then create the configuration file:
 
 ```yaml
 apiVersion: eksctl.io/v1alpha5
@@ -137,7 +148,7 @@ kind: ClusterConfig
 metadata:
   name: CLUSTER_NAME
   region: REGION
-  version: "1.29"
+  version: "1.33"
 
 iam:
   withOIDC: true
@@ -150,29 +161,30 @@ managedNodeGroups:
     maxSize: 5
     desiredCapacity: 5
     volumeSize: 100
-    ssh:
-      allow: true # will use ~/.ssh/id_rsa.pub as the default ssh key
+    # ssh:                              # optional: enable SSH access to the nodes
+    #   allow: true
+    #   publicKeyPath: ~/.ssh/id_ed25519.pub
     iam:
       attachPolicyARNs:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
-        - arn:aws:iam::ECR_AWS_ACCOUNT_ID:policy/POLICYNAME
+        - arn:aws:iam::ECR_AWS_ACCOUNT_ID:policy/POLICY_NAME
       withAddonPolicies:
         awsLoadBalancerController: true
 addons:
   - name: aws-ebs-csi-driver
-    wellKnownPolicies:      # add IAM and service account
+    wellKnownPolicies:      # add IAM role and service account
       ebsCSIController: true
 ```
 
-You can create the EKS cluster using the following eksctl command:
+Create the EKS cluster:
 
 ```bash
 eksctl create cluster -f eksctl.yaml --profile PROFILE
 ```
 
-Once the creation process is completed, you should be able to access the cluster using the kubectl CLI tool:
+Once the cluster is created, verify that you can access it with the kubectl CLI tool:
 
 ```bash
 kubectl get nodes
@@ -180,9 +192,9 @@ kubectl get nodes
 
 You should see the list of nodes provisioned for the cluster.
 
-### Step 1.4: Install the AWS LoadBalancer Addon
+### Step 1.5: Install the AWS Load Balancer Controller
 
-For Hopsworks to provision the necessary network and application load balancers, we need to install the AWS LoadBalancer plugin (See [AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/lbc-helm.html) )
+For Hopsworks to provision the network and application load balancers it needs, install the AWS Load Balancer Controller (see the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/lbc-helm.html)):
 
 ```bash
 helm repo add eks https://aws.github.io/eks-charts
@@ -190,10 +202,14 @@ helm repo update eks
 helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=CLUSTER_NAME
 ```
 
-### Step 1.5: (Optional) Create GP3 Storage Class
+The controller uses the IAM permissions attached to the node group through the `awsLoadBalancerController` add-on policy enabled above.
+Alternatively, you can run it with a dedicated service account using [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/lbc-helm.html).
+If the controller cannot auto-detect the VPC, pass `--set region=REGION` and `--set vpcId=VPC_ID`.
 
-By default EKS comes with GP2 as storage class.
-GP3 is more cost effective, we can use it with Hopsworks by creating the storage class
+### Step 1.6: Create a GP3 storage class
+
+EKS clusters typically provide `gp2` as the default storage class.
+`gp3` is more cost effective and is the storage class referenced by the Helm values below (`storageClassName: ebs-gp3`), so create it:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -211,31 +227,47 @@ allowVolumeExpansion: true
 EOF
 ```
 
-## Step 2: Hopsworks Deployment
+If you prefer to keep the default `gp2` storage class, set `storageClassName` to `gp2` in the Helm values and skip this step.
 
-This section describes the steps required to deploy the Hopsworks stack using Helm.
+### Step 1.7: Request an ACM certificate for your domain
+
+HTTPS is required to access the Hopsworks UI.
+The application load balancer that the AWS Load Balancer Controller provisions terminates TLS using a certificate from AWS Certificate Manager (ACM), and its ARN must already exist when you set the `alb.ingress.kubernetes.io/certificate-arn` annotation in the Helm values (Step 2.3).
+The chart does not create this certificate, so request (or import) one in the same region as the cluster, covering the domain you will use as `HOST_DOMAIN`:
+
+```bash
+aws acm request-certificate --domain-name HOST_DOMAIN --validation-method DNS --region REGION --profile PROFILE
+```
+
+Complete the DNS validation in ACM, then note the certificate ARN.
+The end-to-end order is: create and validate the certificate first, set its ARN in the values file (Step 2.3), install the chart (Step 2.4) which provisions the load balancer, then point the `HOST_DOMAIN` DNS record at that load balancer (Step 3.1).
+
+## Step 2: Deploy Hopsworks
+
+This section describes how to deploy the Hopsworks stack using Helm.
 
 ### Step 2.1: Add the Hopsworks Helm repository
 
-- Configure Repo
+To obtain access to the Hopsworks Helm chart repository, please [obtain](https://www.hopsworks.ai/try) an evaluation/startup licence.
 
-To obtain access to the Hopsworks helm chart repository, please [obtain](https://www.hopsworks.ai/try) an evaluation/startup licence.
-
-Once you have the helm chart repository URL, replace the environment
-variable $HOPSWORKS_REPO in the following command with this URL.
+Once you have the Helm chart repository URL, replace the environment variable $HOPSWORKS_REPO in the following command with this URL:
 
 ```bash
 helm repo add hopsworks $HOPSWORKS_REPO
 helm repo update hopsworks
 ```
 
-- Create Hopsworks namespace
+### Step 2.2: Create the Hopsworks namespace
 
 ```bash
 kubectl create namespace hopsworks
 ```
 
-- Update values.aws.yml
+### Step 2.3: Create the Helm values file
+
+Create a `values.aws.yaml` file with the following content.
+This example covers the values needed for a basic deployment; see the [Helm chart values reference][helm-chart-values-reference] for the full list of configurable values.
+Update the placeholders (ECR_AWS_ACCOUNT_ID, REGION, NAMESPACE, BUCKET_NAME, the certificate ARN from Step 1.7, and HOST_DOMAIN) with your values:
 
 ```yaml
 global:
@@ -254,10 +286,10 @@ global:
     managedObjectStorage:
       enabled: true
       s3:
-        bucket: 
+        bucket:
           name: "BUCKET_NAME"
         region: "REGION"
-    
+
     minio:
       enabled: false
 
@@ -268,6 +300,13 @@ global:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 
 hopsworks:
+  # RonDB and OpenSearch back up automatically to the S3 bucket above; Kubernetes
+  # resource backups instead use Velero, which needs a separate install. Disable
+  # the Velero backup so the chart's Velero prerequisite check does not fail the
+  # install. See the Disaster Recovery guide to install Velero and enable it.
+  velero:
+    backup:
+      enabled: false
   variables:
     # awsregcred Secret contains the docker configuration to use Cloud
     # specific docker login helper method instead of username/password
@@ -288,7 +327,7 @@ hopsworks:
     ingressClassName: alb
     annotations:
       alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxx
+      alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:REGION:ACCOUNT_ID:certificate/CERTIFICATE_ID
       alb.ingress.kubernetes.io/target-type: ip
       alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=300
 
@@ -298,6 +337,17 @@ hopsworks:
     tls:
       - hosts:
         - *host
+
+kafka:
+  cluster:
+    kafka:
+      externalLoadBalancer:
+        # The AWS Load Balancer Controller uses this finalizer to deprovision
+        # the Kafka network load balancers on teardown. Strimzi manages the
+        # broker and bootstrap Services, so the finalizer must be set here to
+        # avoid orphaned load balancers when the release is uninstalled.
+        finalizers:
+        - service.k8s.aws/resources
 
 rondb:
   rondb:
@@ -319,25 +369,73 @@ prometheus:
         storageClass: *storageClass
 ```
 
-- Run the Helm install
+RonDB and OpenSearch back up automatically to the S3 bucket, which is why versioning must be enabled on it (Step 1.1).
+Kubernetes-resource backups instead use Velero, which requires a separate installation, so they are disabled above (`hopsworks.velero.backup.enabled: false`) to keep the chart's Velero prerequisite check from failing the install.
+To enable them, follow the [Disaster Recovery guide][disaster-recovery] to install Velero with the AWS plugin.
 
-```bash
-helm install hopsworks hopsworks/hopsworks --namespace hopsworks --values values.aws.yaml --timeout=600s
+The `awsregcred` Docker registry secret referenced above is generated by the chart, because `cloudProvider` is `AWS` and `credHelper.enabled` is `true`.
+You do not create it manually (unlike on Azure, where the credential helper is not available).
+
+If you use model serving (KServe), update the allowed CORS origin to your domain, otherwise the browser is blocked from calling the model serving endpoints from the Hopsworks UI.
+The allowlist defaults to a placeholder host, so add your domain to `values.aws.yaml`:
+
+```yaml
+kserve:
+  istio:
+    envoyFilter:
+      corsAllowedOrigins:
+        - https://HOST_DOMAIN
 ```
 
-Using the kubectl CLI tool, you can track the deployment process.
-You can use the command below to track which pods are running and which ones are in the process of being provisioned.
-You can also use the command below to detect any failure.
+### Step 2.4: Install the Helm chart
+
+```bash
+helm install hopsworks hopsworks/hopsworks --namespace hopsworks --values values.aws.yaml --timeout=3600s
+```
+
+A first install pulls and syncs large base images and provisions stateful services, so allow up to an hour to complete; the chart's own deployment examples use `--timeout=3600s`.
+A Helm timeout does not roll back the release — the deployment keeps reconciling in the background — so if it times out, track progress with kubectl rather than reinstalling:
 
 ```bash
 kubectl -n hopsworks get pods
 ```
 
-## Step 3: Resources Created
+The command above shows which pods are running and which are still being provisioned.
 
-Using the Helm chart and the values files the following resources are created:
+## Step 3: Access Hopsworks
 
-Load Balancers:
+Once all pods in the `hopsworks` namespace are running, the Hopsworks UI is reachable over HTTPS at the `HOST_DOMAIN` you configured in the Ingress.
+Before that hostname resolves, you have to point it at the application load balancer that the AWS Load Balancer Controller provisioned.
+
+### Step 3.1: Find the load balancer hostname and create a DNS record
+
+Get the address of the application load balancer created for the Ingress:
+
+```bash
+kubectl get ingress -n hopsworks
+```
+
+The `ADDRESS` column shows the load balancer DNS name, for example `k8s-hopsworks-xxxxxxxxxx.REGION.elb.amazonaws.com`.
+If `ADDRESS` is empty, wait a minute and retry, because the controller provisions the load balancer asynchronously.
+
+In your DNS provider, create a record mapping `HOST_DOMAIN` to this load balancer DNS name (a CNAME on most providers, or an alias/A record to the load balancer in Route 53).
+The `HOST_DOMAIN` must be covered by the ACM certificate from Step 1.7, otherwise the browser rejects the TLS connection.
+
+### Step 3.2: Log in
+
+Open `https://HOST_DOMAIN` in your browser and log in with the default administrator account:
+
+- Username: `admin@hopsworks.ai`
+- Password: `admin`
+
+Change this password immediately after the first login, because these defaults are public and identical across every installation.
+To start with a different password, set `hopsworks.variables.admin_password` (and `hopsworks.variables.admin_email`) in the values file before installing.
+
+## Resources created
+
+Using the Helm chart and the values file, the following resources are created.
+
+### Load balancers
 
 ```yaml
     externalLoadBalancers:
@@ -347,34 +445,34 @@ Load Balancers:
         service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
 ```
 
-Enabling the external load balancer in the values.yml file provisions the following load balancers for the following services:
+Enabling the external load balancers in the values file provisions a load balancer for each of the following services:
 
-- arrowflight : This load balancer is used to send queries from external clients to the Hopsworks Query Service
+- arrowflight: sends queries from external clients to the Hopsworks Query Service.
+- kafka: sends data to the Apache Kafka brokers for ingestion into the online feature store.
+- rdrs: queries online feature store data using the REST APIs.
+- mysql: queries online feature store data using the MySQL APIs.
+- opensearch: queries the Hopsworks vector database.
+- namenode and datanode: external access to the HopsFS file system.
 
-- kafka : This load balancer is used to send data to the Apache Kafka brokers for ingestion to the online feature store.
+On EKS, the AWS Load Balancer Controller installed above is responsible for provisioning these load balancers.
+You can configure them using the annotations documented in the [AWS Load Balancer Controller guide](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/).
 
-- rdrs: This load balancer is used to query online feature store data using the REST APIs
+Each service has its own `externalLoadBalancer.enabled` (or, for HopsFS, `loadBalancer.enabled`) value, nested inside the relevant subchart.
+When that value is left unset it inherits `global._hopsworks.externalLoadBalancers.enabled`, which defaults to `true`, so all of these load balancers are provisioned unless you disable them.
+The exact value paths are:
 
-- mysql: This load balancer is used to query online feature store data using the MySQL APIs
+- `arrowflight.externalLoadBalancer.enabled`
+- `kafka.cluster.kafka.externalLoadBalancer.enabled`
+- `rondb.rondb.meta.rdrs.externalLoadBalancer.enabled` (rdrs)
+- `rondb.rondb.meta.mysqld.externalLoadBalancer.enabled` (mysql)
+- `olk.opensearch.externalLoadBalancer.enabled` (opensearch)
+- `hopsfs.namenode.loadBalancer.enabled` (namenode)
+- `hopsfs.datanode.loadBalancer.enabled` (datanode)
+- `trino.externalLoadBalancer.enabled` (only when Trino is enabled)
 
-- opensearch : This load balancer is used to query the Hopsworks vector database
+Other load balancer providers are also supported by providing the appropriate controller, class, and annotations.
 
-On EKS using the AWS Load Balancers, the AWS controller deployed above will be responsible to provision the necessary load balancers.
-You can configure the load balancers using the annotations documented in the [AWS Load Balancer controller guide](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/)
-
-You can enable/disable individual load balancers provisioning using the following values in the values.yml file:
-
-- kafka.externalLoadBalancer.enabled
-
-- opensearch.externalLoadBalancer.enabled
-
-- rdrs.externalLoadBalancer.enabled
-
-- mysql.externalLoadBalancer.enabled
-
-Other load balancer providers are also supported by providing the appropriate controller, class and annotations.
-
-Ingress:
+### Ingress
 
 ```yaml
   ingress:
@@ -384,28 +482,30 @@ Ingress:
       alb.ingress.kubernetes.io/scheme: internet-facing
 ```
 
-Hopsworks UI and REST interface is available outside the K8s cluster using an Ingress.
-On AWS this is implemented by provisioning an application load balancer using the AWS load balancer controller.
-As per the load balancer above, the controller checks for the following annotations: [Annotations - AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/)
+The Hopsworks UI and REST interface are available outside the Kubernetes cluster through an Ingress.
+On AWS this is implemented by provisioning an application load balancer using the AWS Load Balancer Controller, which reads the [Ingress annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/).
 
-HTTPS is required to access the Hopsworks UI, therefore you need to add the following annotation:
+HTTPS is required to access the Hopsworks UI, so the Ingress must reference an ACM certificate (Step 1.7) through this annotation:
 
 ```bash
-alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxx
+alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:REGION:ACCOUNT_ID:certificate/CERTIFICATE_ID
 ```
 
-To configure the TLS certificate the Application Load Balancer should use to terminate the connection.
-The certificate should be available in the [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/)
+This configures the TLS certificate that the application load balancer uses to terminate the connection.
+The certificate must be available in the [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) and cover your `HOST_DOMAIN`.
 
-Cluster Roles and Cluster Role Bindings:
+The chart does not create a DNS record for you.
+After the Ingress is provisioned, find the load balancer hostname with `kubectl get ingress -n hopsworks` and point your `HOST_DOMAIN` at it, as described in Step 3.1.
 
-By default a set of cluster roles are provisioned, if you don’t have permissions to provision cluster roles or cluster role bindings, you should reach out to your K8s administrator.
-You should then provide the appropriate resource names as value in the values.yml file.
+### Cluster roles and cluster role bindings
 
-## Step 4: Next steps
+By default a set of cluster roles is provisioned.
+If you don't have permissions to provision cluster roles or cluster role bindings, reach out to your Kubernetes administrator and provide the appropriate resource names as values in the values file.
+
+## Next steps
 
 Check out our other guides for how to get started with Hopsworks and the Feature Store:
 
 - Get started with the [Hopsworks Feature Store](https://colab.research.google.com/github/logicalclocks/hopsworks-tutorials/blob/master/quickstart.ipynb){:target="_blank"}
 - Follow one of our [tutorials](../../tutorials/index.md)
-- Follow one of our [Guide](../../user_guides/index.md)
+- Follow one of our [guides](../../user_guides/index.md)

--- a/docs/setup_installation/azure/getting_started.md
+++ b/docs/setup_installation/azure/getting_started.md
@@ -167,6 +167,7 @@ helm repo update hopsworks
 ### Step 4.2: Create helm values file
 
 Below is a simplifield values.azure.yaml file to get started which can be updated for improved performance and further customisation.
+See the [Helm chart values reference][helm-chart-values-reference] for the full list of configurable values.
 
 ```yaml
 global:

--- a/docs/setup_installation/common/helm_chart_values.md
+++ b/docs/setup_installation/common/helm_chart_values.md
@@ -1,0 +1,16 @@
+# Helm chart values reference
+
+This page lists every value you can configure when deploying Hopsworks with the Hopsworks Helm chart.
+It is generated from the chart's `README.md`.
+On a released version of the docs it matches the Hopsworks Helm chart for that release; on the development docs it reflects the latest chart published to the development channel.
+
+You set these values in the `values.<cloud>.yaml` file that you pass to `helm install`.
+For a guided, end-to-end setup, follow one of the cloud installation guides, such as the [AWS getting started guide][aws-getting-started-with-eks].
+Only a small subset of these values is needed for a typical install; the table below is the exhaustive reference.
+
+## Configuration values
+
+<!-- BEGIN GENERATED VALUES -->
+_The values table is generated from the Hopsworks Helm chart during the documentation build._
+_To preview it locally, run `uv run --extra cli hopsworks-docs gen-helm-values --chart <path-to-hopsworks-helm>`._
+<!-- END GENERATED VALUES -->

--- a/docs/setup_installation/gcp/getting_started.md
+++ b/docs/setup_installation/gcp/getting_started.md
@@ -143,6 +143,7 @@ kubectl create namespace hopsworks
 ### Step 3.3: Create helm values file
 
 Below is a simplifield values.gcp.yaml file to get started which can be updated for improved performance and further customisation.
+See the [Helm chart values reference][helm-chart-values-reference] for the full list of configurable values.
 
 ```bash
 global:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -291,6 +291,7 @@ nav:
           - Query Engine (Trino): setup_installation/admin/trino.md
           - Superset: setup_installation/admin/superset.md
       - ArrowFlight Server with DuckDB: setup_installation/common/arrow_flight_duckdb.md
+      - Helm Chart Values Reference: setup_installation/common/helm_chart_values.md
   - Python API: python-api
   - Java API: javadoc
   - Community ↗: https://community.hopsworks.ai/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cli = ["typer", "rich"]
+cli = ["typer", "rich", "pyyaml", "packaging"]
 
 [dependency-groups]
 dev = ["ruff==0.15.6", "linkchecker", "md-snakeoil", "pyright"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,6 +1,7 @@
 import typer
 
 from .check import check
+from .helm_values import gen_helm_values
 from .linkchecker import linkchecker
 from .markdownlint import markdownlint
 from .serve import serve
@@ -14,3 +15,4 @@ cli.command()(serve)
 cli.command()(markdownlint)
 cli.command()(linkchecker)
 cli.command()(snakeoil)
+cli.command()(gen_helm_values)

--- a/scripts/helm_values.py
+++ b/scripts/helm_values.py
@@ -1,0 +1,262 @@
+import base64
+import io
+import re
+import tarfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Annotated
+
+import typer
+import yaml
+from hopsworks_docs.scripts.shared.docs_root import _DOCS_ROOT
+from packaging.version import InvalidVersion, Version
+
+
+_DEFAULT_PAGE = (
+    _DOCS_ROOT / "docs" / "setup_installation" / "common" / "helm_chart_values.md"
+)
+_VALUES_HEADING = "\n## Values\n"
+_BEGIN = "<!-- BEGIN GENERATED VALUES -->"
+_END = "<!-- END GENERATED VALUES -->"
+
+# Inline code spans and genuine external links are kept verbatim; everything
+# else has its square brackets escaped (see _neutralize_markdown_refs). The link
+# pattern is single-line (no newlines in the text or URL) so it cannot swallow
+# whole table rows when a description's URL has no closing paren on its line.
+_CODE_SPAN = re.compile(r"`[^`]*`")
+_EXTERNAL_LINK = re.compile(r"\[[^\]\n]+\]\(https?://[^)\s]+\)")
+# Private-use code points that cannot occur in the README, used to stash the
+# protected spans while brackets are escaped.
+_HOLD_OPEN = chr(0xE000)
+_HOLD_CLOSE = chr(0xE001)
+_HOLD_RE = re.compile(re.escape(_HOLD_OPEN) + r"(\d+)" + re.escape(_HOLD_CLOSE))
+
+
+def _neutralize_markdown_refs(text: str) -> str:
+    """Escape bracket-based link/reference syntax in helm-docs descriptions.
+
+    helm-docs descriptions occasionally contain Markdown links to relative
+    paths (e.g. ``[values.yaml](./values.yaml)``) or reference-style brackets
+    (e.g. ``key[=value][:effect]``). mkdocs treats the former as broken doc
+    links and mkdocs-autorefs treats the latter as unresolved cross-references,
+    both of which fail the strict build. Escape square brackets so they render
+    as literal text, while leaving inline code spans (the default values) and
+    genuine ``http(s)`` links untouched.
+    """
+    stash: list[str] = []
+
+    def _hold(match: re.Match) -> str:
+        stash.append(match.group(0))
+        return f"{_HOLD_OPEN}{len(stash) - 1}{_HOLD_CLOSE}"
+
+    text = _CODE_SPAN.sub(_hold, text)
+    text = _EXTERNAL_LINK.sub(_hold, text)
+    text = text.replace("[", "\\[").replace("]", "\\]")
+    # Un-stash iteratively: a stashed span can itself contain sentinels for
+    # other stashed spans, which a single pass would leave unresolved and leak
+    # the literal private-use characters into the page. An index that was never
+    # stashed (a stray sentinel already in the README) degrades to literal text
+    # rather than crashing, matching the module's graceful-degradation contract.
+    def _restore(m: re.Match) -> str:
+        idx = int(m.group(1))
+        return stash[idx] if idx < len(stash) else m.group(0)
+
+    while _HOLD_RE.search(text):
+        new = _HOLD_RE.sub(_restore, text)
+        if new == text:  # nothing resolvable left; avoid an infinite loop
+            break
+        text = new
+    return text
+
+
+def _http_get(url: str, username: str, password: str) -> bytes:
+    """GET a URL, optionally with HTTP basic auth. Fail loudly on errors."""
+    request = urllib.request.Request(url)
+    if username:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        request.add_header("Authorization", f"Basic {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:  # noqa: S310
+            return response.read()
+    except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+        typer.echo(f"ERROR: failed to fetch {url}: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+
+def _select_chart(entries: list[dict], chart_version: str | None) -> dict | None:
+    """Pick the chart entry to document from a Helm repo index.
+
+    With ``chart_version`` (release docs), keep entries whose chart ``version``
+    is that major.minor (or an exact match) and pick the highest patch by
+    semver. Without it (dev docs), pick the most recently published entry by the
+    index ``created`` timestamp -- dev charts are time-stamped pre-releases, so
+    newest-published is the latest dev build.
+    """
+    if not chart_version:
+        return max(entries, key=lambda e: str(e.get("created", ""))) if entries else None
+
+    candidates = [
+        e
+        for e in entries
+        if str(e.get("version", "")) == chart_version
+        or str(e.get("version", "")).startswith(f"{chart_version}.")
+    ]
+    if not candidates:
+        return None
+
+    def _parse(entry: dict) -> Version | None:
+        try:
+            return Version(str(entry.get("version", "")))
+        except InvalidVersion:
+            return None
+
+    parseable = [(e, v) for e in candidates if (v := _parse(e)) is not None]
+    if parseable:
+        return max(parseable, key=lambda pair: pair[1])[0]
+    # Fall back to newest-published if none of the versions are valid semver.
+    return max(candidates, key=lambda e: str(e.get("created", "")))
+
+
+def _readme_from_registry(
+    repo_url: str, chart_version: str | None, username: str, password: str
+) -> tuple[str, str, str] | None:
+    """Resolve a chart in a Helm (Nexus) repo and return (readme, version, appVersion).
+
+    Returns None (and warns) if nothing suitable is found, so the build keeps
+    the page placeholder instead of failing.
+    """
+    base = repo_url.rstrip("/")
+    # `or {}` guards an empty/invalid index.yaml (safe_load returns None) so a
+    # bad response keeps the placeholder rather than raising AttributeError.
+    index = yaml.safe_load(_http_get(f"{base}/index.yaml", username, password)) or {}
+    entries = (index.get("entries") or {}).get("hopsworks") or []
+
+    chosen = _select_chart(entries, chart_version)
+    if chosen is None:
+        typer.echo(
+            f"WARNING: no chart in {base} matches version "
+            f"'{chart_version or 'any'}'; leaving the page placeholder.",
+            err=True,
+        )
+        return None
+
+    urls = chosen.get("urls") or []
+    if not urls:
+        typer.echo(
+            f"WARNING: chart {chosen.get('version')} has no download URL; "
+            "leaving the page placeholder.",
+            err=True,
+        )
+        return None
+
+    url = urls[0]
+    if not url.startswith(("http://", "https://")):
+        url = f"{base}/{url.lstrip('/')}"
+    version = str(chosen.get("version", ""))
+    app_version = str(chosen.get("appVersion", ""))
+    typer.echo(f"Using chart {version} (appVersion {app_version}) from {base}")
+
+    archive = _http_get(url, username, password)
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar:
+        # The chart README is the top-level "<chart>/README.md" (one slash);
+        # deeper matches are subchart READMEs. Require a regular file so a
+        # directory/symlink/special member never reaches extractfile() (which
+        # would return None) and crash instead of skipping gracefully.
+        member = next(
+            (
+                m
+                for m in tar.getmembers()
+                if m.isfile()
+                and m.name.count("/") == 1
+                and m.name.endswith("/README.md")
+            ),
+            None,
+        )
+        if member is None:
+            typer.echo(
+                "WARNING: README.md not found in the chart package; "
+                "leaving the page placeholder.",
+                err=True,
+            )
+            return None
+        extracted = tar.extractfile(member)
+        return extracted.read().decode("utf-8"), version, app_version
+
+
+def gen_helm_values(
+    chart: Annotated[
+        Path | None,
+        typer.Option(help="Path to a local hopsworks-helm checkout (preview)."),
+    ] = None,
+    repo_url: Annotated[
+        str | None,
+        typer.Option(help="Nexus Helm repo base URL to fetch the chart from."),
+    ] = None,
+    chart_version: Annotated[
+        str | None,
+        typer.Option(
+            help="Chart version major.minor to match, picking the latest patch, "
+            "e.g. 4.8 (release docs). Omit for the latest published chart "
+            "(e.g. the dev channel)."
+        ),
+    ] = None,
+    username: Annotated[
+        str,
+        typer.Option(envvar="NEXUS_USER", help="Nexus username (private repos)."),
+    ] = "",
+    password: Annotated[
+        str,
+        typer.Option(envvar="NEXUS_PASSWORD", help="Nexus password (private repos)."),
+    ] = "",
+    page: Annotated[
+        Path,
+        typer.Option(help="Reference page to inject the values table into."),
+    ] = _DEFAULT_PAGE,
+) -> None:
+    """Inject the Helm chart README values table into the reference page.
+
+    Source the chart README either from a local checkout (``--chart``) or, for
+    CI, from the published chart package in a Nexus Helm repo (``--repo-url``,
+    optionally ``--chart-version`` for release matching). Slices the ``## Values``
+    table out of that README and writes it, with a line recording the chart
+    version, between the generation markers in ``page``. The result is consumed
+    by the documentation build and is not committed. If no matching chart or no
+    ``## Values`` section is found, the page placeholder is left in place rather
+    than failing the build.
+    """
+    if chart:
+        readme: str = (chart / "README.md").read_text(encoding="utf-8")
+        meta = yaml.safe_load((chart / "Chart.yaml").read_text(encoding="utf-8")) or {}
+        version = str(meta.get("version", ""))
+        app_version = str(meta.get("appVersion", ""))
+    elif repo_url:
+        resolved = _readme_from_registry(repo_url, chart_version, username, password)
+        if resolved is None:
+            return
+        readme, version, app_version = resolved
+    else:
+        raise typer.BadParameter("provide either --chart <dir> or --repo-url <url>")
+
+    if _VALUES_HEADING not in readme:
+        typer.echo(
+            "WARNING: '## Values' section not found in the chart README "
+            "(older chart versions predate it); leaving the page placeholder.",
+            err=True,
+        )
+        return
+    # The '## Values' section is the last one in the README, so take everything
+    # after its heading to EOF -- that is the full Key/Type/Default/Description table.
+    table = _neutralize_markdown_refs(readme.split(_VALUES_HEADING, 1)[1].strip())
+
+    note = f"_Generated from the Hopsworks Helm chart `{version}`"
+    note += f" (Hopsworks `{app_version}`)._" if app_version else "._"
+
+    content = page.read_text()
+    if _BEGIN not in content or _END not in content:
+        msg = f"Injection markers ({_BEGIN} / {_END}) not found in {page}"
+        raise typer.BadParameter(msg)
+    head = content[: content.index(_BEGIN) + len(_BEGIN)]
+    tail = content[content.index(_END) :]
+    page.write_text(f"{head}\n\n{note}\n\n{table}\n\n{tail}")
+    typer.echo(f"Injected chart {version} values ({table.count(chr(10)) + 1} lines)")


### PR DESCRIPTION
## Summary

Overhaul the AWS EKS getting started guide (verified against the Hopsworks Helm chart) and add a Helm chart values reference generated at documentation build time.

### AWS getting started
- Fix the per-service external load-balancer enable/disable value paths — the documented ones did not exist; the real toggles are nested under the subcharts (`kafka.cluster.kafka...`, `olk.opensearch...`, `rondb.rondb.meta.{mysqld,rdrs}...`, `arrowflight...`, `hopsfs.{namenode,datanode}.loadBalancer...`).
- Disable only the Velero (Kubernetes-resource) backup so the install does not fail its Velero prerequisite check, while keeping the RonDB/OpenSearch/HopsFS object-storage backups; enable S3 bucket versioning that those backups rely on.
- Add an ACM certificate step, a post-install **Access Hopsworks** section (DNS record + correct default login `admin@hopsworks.ai`/`admin`), correct the supported Kubernetes range, and note that S3/ECR access uses the node instance IAM role.

### Helm chart values reference
- New page `docs/setup_installation/common/helm_chart_values.md`, committed as a placeholder; the values table is injected at build time and is never committed.
- New `hopsworks-docs gen-helm-values` CLI that slices the chart README's `## Values` table from the Nexus-published chart: release docs read the public `hopsworks-helm` repo anonymously by chart version (highest patch), dev docs read `hopsworks-helm-dev` with `NEXUS_USER`/`NEXUS_PASSWORD`.
- Wire the generation step into the test/release workflows, add the nav entry, and cross-link the reference from the AWS/Azure/GCP guides.

### Misc
- README: install `hopsworks[python]` (hsfs imports pyarrow); document the values-reference build step and its secrets.
- Declare `pyyaml`/`packaging` in the `cli` extra (used directly by the new CLI).

## Reviewer note

The development-docs build (`main`) needs new **read-only** repository secrets **`NEXUS_USER`** and **`NEXUS_PASSWORD`** for the `hopsworks-helm-dev` Nexus repo. Release builds (`branch-x.y`) need nothing — they read the public repo anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
