### PR TITLE
[HWORKS-2849] Fix broken SDK examples found by post-refactor doc audit

### DIFF
--- a/docs/user_guides/mlops/registry/model_schema.md
+++ b/docs/user_guides/mlops/registry/model_schema.md
@@ -35,8 +35,8 @@ Currently, we support `pandas.DataFrame, pandas.Series, numpy.ndarray, list`.
 
     ```python
     # Import a Schema and ModelSchema definition
-    from hsml.utils.model_schema import ModelSchema
-    from hsml.utils.schema import Schema
+    from hsml.model_schema import ModelSchema
+    from hsml.schema import Schema
 
 
     # Model inputs for MNIST dataset

--- a/docs/user_guides/projects/git/repository_actions.md
+++ b/docs/user_guides/projects/git/repository_actions.md
@@ -62,7 +62,7 @@ git_repo = git_api.get_repo(REPOSITORY_NAME)
 ### Step 3: Perform the git repository action e.g commit
 
 ```python
-git_repo = git_api.commit("Test commit")
+git_repo.commit("Test commit")
 ```
 
 ### API Reference


### PR DESCRIPTION
## Summary

While auditing every published code example against the post-PEP-8 SDK surface (hopsworks-api #997/#999), two pre-existing broken examples surfaced:

- **model_schema.md**: `from hsml.utils.model_schema import ModelSchema` and `from hsml.utils.schema import Schema` — neither path exists in the SDK (`hsml/utils/` only contains internal schema helpers and does not export these). Correct paths: `hsml.model_schema` / `hsml.schema`, which is what every other doc page already uses.
- **repository_actions.md**: `git_repo = git_api.commit("Test commit")` — `commit()` is a `GitRepo` method, not `GitApi`.

The rest of the docs verified clean: ~150 example calls and 97 unique receiver methods checked against the SDK source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)