### PR TITLE
[HWORKS-2908] Remove the per-project Hive DB from admin project docs

### DIFF
--- a/docs/setup_installation/admin/project.md
+++ b/docs/setup_installation/admin/project.md
@@ -33,12 +33,10 @@ By clicking on the _edit configuration_ link of a project you will be able to ed
 ### Storage
 
 Storage quota represents the amount of data a project can store.
-The storage quota is broken down in three different areas:
+The storage quota is broken down in two different areas:
 
 - **Feature Store**: This represents the storage quota for files and directories stored in the `_featurestore.db` dataset in the project.
 This dataset contains all the feature group offline data for the project.
-- **Hive DB**: This represents the storage quota for files and directories stored in the `[projectName].db` dataset in the project.
-This is a general purpose Hive database for the project that can be used for analytics.
 - **Project**: This represents the storage quota for all the data stored on any other dataset.
 
 Each storage quota is divided into space quota, i.e., how much space the files can consume, and namespace quota, i.e., how many files and directories there can be.
@@ -52,7 +50,6 @@ Administrators can change this default by changing the following configuration i
 hopsworks:
     featurestore_default_quota: [default quota in bytes, -1 to disable]
     hdfs_default_quota: [default quota in bytes, -1 to disable]
-    hive_default_quota: [default quota in bytes, -1 to disable]
 ```
 
 The values specified will be set during project creation and administrators will be able to customize each project using this UI.


### PR DESCRIPTION
## What

Follow-up to HWORKS-2908 (removal of the unused per-project general-purpose Hive database `<project>.db`).

`docs/setup_installation/admin/project.md`:
- Remove the **Hive DB** storage-quota bullet (the `[projectName].db` general-purpose database) — front#1984 removes that UI section.
- Fix the count: storage quota is now broken down into **two** areas (Feature Store + Project), not three.
- Remove the `hive_default_quota` admin variable from the configuration block — helm#2040 removes the variable.

Hive itself, the central HiveMetaStore, the feature store DB, and `featurestore_default_quota` / `hdfs_default_quota` are unchanged.

## Companion PRs
- logicalclocks/hopsworks-ee#3127, logicalclocks/hopsworks-front#1984, logicalclocks/hopsworks-helm#2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)
