### PR TITLE
[HWORKS-2928] Document git auto-redeploy for apps and agent deployments

### DIFF
--- a/docs/user_guides/agents/deployments/index.md
+++ b/docs/user_guides/agents/deployments/index.md
@@ -68,6 +68,53 @@ print(deployment.predict(inputs={"prompt": "hello"}))
 After creation, the deployment appears in the Agent Deployments list where you
 can inspect its status, logs, endpoints, and configuration.
 
+### Deploy from a Git repository
+
+An agent can be served from a Git repository instead of a project file.
+The repository is cloned every time the deployment starts, so a restart picks up whatever the branch points at.
+
+Supported providers are GitHub, GitLab, and BitBucket.
+Configure the provider credentials once under project settings, see [Configure a Git Provider](../../projects/git/configure_git_provider.md).
+
+```python
+deployment = ms.deploy_agent(
+    entry="src/agent.py",  # path inside the repository
+    name="my_agent",
+    git_url="https://github.com/my-org/my-agent.git",
+    git_provider="GitHub",
+    git_branch="main",
+    environment="my_agent",
+)
+```
+
+`entry` is interpreted relative to the repository root rather than as a HopsFS path.
+If you leave `git_branch` unset, the clone follows the repository's default branch.
+
+### Auto-redeploy on new commits
+
+A Git-backed agent can roll itself onto the branch HEAD whenever a new commit is pushed:
+
+```python
+deployment = ms.deploy_agent(
+    entry="src/agent.py",
+    name="my_agent",
+    git_url="https://github.com/my-org/my-agent.git",
+    git_provider="GitHub",
+    git_branch="main",
+    git_auto_redeploy=True,
+    environment="my_agent",
+)
+```
+
+Hopsworks polls the remote branch and rolls the deployment when it moves.
+The running version keeps serving requests until the new one is ready.
+
+The flag only applies to Git-backed agents, and Hopsworks rejects it for an agent deployed from a project file.
+A stopped deployment is not rolled; it clones the branch HEAD on its next start.
+
+The deployment's **Artifact files** card shows the repository, the branch, the commit it is running, and whether auto-redeploy is enabled.
+The entrypoint links to the file in the repository at that commit.
+
 ## Small example
 
 The file below shows a simple agent program that uses LlamaIndex, FastAPI,

--- a/docs/user_guides/projects/apps/index.md
+++ b/docs/user_guides/projects/apps/index.md
@@ -67,6 +67,20 @@ For Streamlit apps, a project file must be a `.py` file.
 For Git-backed Streamlit apps, you also need to provide the entrypoint script relative to the repository root.
 For custom apps, the entrypoint command is required and the app file is optional.
 
+#### Auto-redeploy on new commits
+
+Git-backed apps can roll themselves to the branch HEAD whenever a new commit is pushed.
+Enable **Auto-redeploy on new commits** in the app settings, or pass `git_auto_redeploy=True` to the SDK.
+
+Hopsworks polls the remote branch and, when it moves, rolls the app onto the new commit.
+The running app keeps serving until the new version is ready, so there is no gap in availability.
+While the roll is in progress the app shows **Redeploying** in the apps list.
+
+The setting only applies to Git-backed apps.
+An app without a Git source has nothing to poll, and Hopsworks rejects the flag in that case.
+
+If you do not set a branch, the clone follows the repository's default branch, and the app details page shows the branch it resolved to once the app has run.
+
 ### Routing and readiness
 
 The browser URL for every app is the public mount point under `/hopsworks-api/pythonapp/<project>/<app>/`.
@@ -207,7 +221,7 @@ The details page includes:
 - App URL
 - App base path, proxy routing mode, and readiness probe path
 - Public access status for Streamlit apps
-- Git source details, if the app is Git-backed
+- Git source details, if the app is Git-backed, including the branch, the deployed commit, and whether auto-redeploy is enabled
 - Monitoring configuration
 - Resource requests
 - Runtime environment
@@ -262,6 +276,20 @@ app.run()
 print(app.app_url)
 ```
 
+A Git-backed app that redeploys itself on every push:
+
+```python
+app = apps.create_app(
+    "customer_dashboard",
+    app_kind="STREAMLIT",
+    git_url="https://github.com/my-org/my-app.git",
+    git_provider="GitHub",
+    git_branch="main",
+    git_auto_redeploy=True,
+    entrypoint_script="src/app.py",
+)
+```
+
 Common SDK methods:
 
 - `project.get_app_api()`
@@ -291,6 +319,7 @@ hops app delete <name> --yes
 
 Use `--git-url` and `--entrypoint-script` for Git-backed Streamlit apps.
 Use `--entrypoint-command` and `--app-port` for custom apps.
+Add `--git-auto-redeploy` to roll a Git-backed app onto every new commit.
 
 ## See also
 


### PR DESCRIPTION
Apps: an "Auto-redeploy on new commits" subsection under App sources, the setting in the SDK and CLI examples, and the git details the app page now shows. Note the REDEPLOYING state during a roll, and that an app without a branch follows the repository default and reports the branch it resolved to.

Agent deployments had no git documentation at all, so this adds deploying from a repository as well as auto-redeploy: the entry path being relative to the repository root, the supported providers with a link to the provider setup, and what the Artifact files card shows.