### PR TITLE
[HWORKS-2807] Append - fix loadtests and connectors

### DIFF
--- a/docs/user_guides/fs/data_source/creation/snowflake.md
+++ b/docs/user_guides/fs/data_source/creation/snowflake.md
@@ -75,7 +75,10 @@ Start by giving it a **name** and an optional **description**.
 01. Select "Snowflake" as storage.
 02. Specify the hostname for your account in the following format `<account_identifier>.snowflakecomputing.com` or `https://<orgname>-<account_name>.snowflakecomputing.com`.
 03. Login name for the Snowflake user.
-04. **Authentication** Choose between user account Password, Token or Private Key options.
+04. **Authentication** Choose between Password / Programmatic Access Token (PAT), Token or Private Key options.
+    Snowflake is removing single-factor password sign-ins, so supply a programmatic access token (PAT) in the
+    Password / PAT field rather than an account password. The Token option accepts OAuth access tokens only and
+    rejects a PAT with `390303 Invalid OAuth access token`.
     In case of private key, upload your snowflake user Private Key file and set Passphrase if applicable.
 05. The warehouse to connect to.
 06. The database to use for the connection.


### PR DESCRIPTION
## Why

Snowflake is removing single-factor password sign-ins, so the account password behind the Snowflake data source stops working. A programmatic access token (PAT) takes its place.

PATs need the `password` field. The connector `token` field renders `authenticator=oauth`, which Snowflake rejects for PATs. Verified against a live account:

- `X-Snowflake-Authorization-Token-Type: PROGRAMMATIC_ACCESS_TOKEN` -> HTTP 200
- `X-Snowflake-Authorization-Token-Type: OAUTH` -> HTTP 401 `390303 Invalid OAuth access token`

The JDBC driver behind `net.snowflake.spark.snowflake` has no PAT authenticator either, so a PAT is passed in the password position. The password auth method is therefore relabelled rather than removed, which keeps PAT support available.

## What changed

Step 04 of the Snowflake data source creation guide now matches the relabelled authentication options, and states that the Token option accepts OAuth access tokens only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs

Same branch, same ticket, one per repo:

- logicalclocks/hopsworks-helm#2152 (loadtest CI)
- logicalclocks/hopsworks-front#2015 (UI relabel)
- logicalclocks/hopsworks-api#1071 (docstrings)
- logicalclocks/logicalclocks.github.io#621 (docs)
