### PR TITLE
[FSTORE-2086] Add support for disabling Uploads to Hopsworks

### DIFF
--- a/docs/setup_installation/admin/variables.md
+++ b/docs/setup_installation/admin/variables.md
@@ -47,3 +47,26 @@ Once you have set the desired properties, you can persist them by clicking *Crea
   <img src="../../../assets/images/admin/variables/new-variable.png" alt="Adding a new configuration property" />
   <figcaption>Adding a new configuration property</figcaption>
 </figure>
+
+## Restricting file uploads
+
+The `upload_policy` configuration controls who may upload files into the cluster.
+Uploads are otherwise available to every user with write access to a dataset, so this setting exists for clusters that ingest data only through governed pipelines, or that have to limit what enters the platform.
+
+| Value | Who may upload |
+| ----- | -------------- |
+| `enabled` | Any user with write access to the destination dataset. This is the default, so an existing cluster is unaffected until the value is changed. |
+| `admins_only` | Only members of the `HOPS_ADMIN` group. |
+| `disabled` | Nobody, administrators included. |
+
+The policy is enforced by the backend, so it applies to the Hopsworks UI and to clients such as the Python API alike.
+A refused upload returns HTTP 403.
+In the UI the upload controls are disabled instead, so a blocked user is told before starting an upload rather than watching it fail.
+
+You can set the value from the *Configuration* page described above, or at deploy time through the `hopsworks.variables.upload_policy` value of the Helm chart.
+A value set in the Helm chart is reapplied on every upgrade, so a change made from the Configuration page holds until the cluster is next upgraded.
+Any value other than the three above is treated as `enabled`, so that a typo cannot block uploads without anyone noticing.
+
+This setting governs uploading new files into the cluster, and nothing else.
+It does not restrict operations that only reference files already in the cluster filesystem, such as installing a Python library from a requirements file that is already in a project, because no file is transferred in that case.
+It also does not remove files that were uploaded before the value was changed.


### PR DESCRIPTION
Part of FSTORE-2086. Backend PR: logicalclocks/hopsworks-ee#3224

## What

Documents the new `upload_policy` cluster configuration on the Cluster Configuration page: the three values (`enabled`, `admins_only`, `disabled`), that the backend enforces the policy so it covers the Python API as well as the UI, and that a refused upload returns HTTP 403 while the UI disables the controls instead.

## Why these particular points are called out

- **The two ways of setting it interact.** A value set in the Helm chart is reapplied on every upgrade, so a change made from the Configuration page holds only until the cluster is next upgraded. Someone who sets this from the UI and expects it to persist would otherwise be surprised by an upgrade quietly restoring the chart value.
- **The name overpromises.** "Uploads disabled" reads as stronger than it is, so the page states the limits: the policy governs uploading new files only, it does not stop a python library being installed from a requirements file already in a project, and it does not remove files uploaded before the value changed.
- **Unrecognised values fall back to `enabled`.** Documented so an operator who mistypes the value does not assume uploads are blocked when they are not.

## Placement

Added as a section on `setup_installation/admin/variables.md` rather than a new page. That page is the Cluster Configuration reference, and no page in the repo documents individual variables, so there was no per-variable reference to extend. No `mkdocs.yml` nav change is needed for a section on an existing page.

Follows the repo conventions: one sentence per line, and no restriction stated without its reason.

## Testing

`npx markdownlint-cli2 docs/setup_installation/admin/variables.md` — 0 errors.

The full `mkdocs build -s` was not run; it needs the uv environment plus the `hopsworks-api` install for the API docs section, and this change adds no new page, link, or nav entry that a build would newly validate.

Ticket: https://hopsworks.atlassian.net/browse/FSTORE-2086
