### PR TITLE
[HWORKS-2991][APPEND][HWORKS-3040] Correct conda-era docs claims, and document installing a compiler

### DIFF
--- a/docs/concepts/dev/inside.md
+++ b/docs/concepts/dev/inside.md
@@ -25,7 +25,7 @@ This architecture consists of three independently developed and operated ML pipe
 - Inference pipeline: takes new feature data and a trained model and makes predictions
 
 In order to facilitate the development of these pipelines Hopsworks bundles several python environments containing necessary dependencies.
-Each of these environments may then also be customized further by cloning it and installing additional dependencies from PyPi, Conda channels, Wheel files, GitHub repos or a custom Dockerfile.
+Each of these environments may then also be customized further by cloning it and installing additional dependencies from PyPi, Wheel files, GitHub repos or a custom Dockerfile.
 Internal compute such as Jobs and Jupyter is run in one of these environments and changes are applied transparently when you install new libraries using our APIs.
 That is, there is no need to write a Dockerfile, users install libraries directly in one or more of the environments.
 You can setup custom development and production environments by creating separate projects or creating multiple clones of an environment within the same project.

--- a/docs/user_guides/projects/python/custom_commands.md
+++ b/docs/user_guides/projects/python/custom_commands.md
@@ -62,13 +62,45 @@ There are few important things to be aware of when writing the bash script:
   We have already configured `apt-get` to be non-interactive
 - The build artifacts will be copied to `srv/hops/build`.
   You can use them in your script via this path.
-  This path is also available via the environmental variable `BUILD_PATH`.
+  This path is also available via the environment variable `BUILD_DIR`.
   If you want to use many artifacts it is advisable to create a zip file and upload it to HopsFS in one of your project datasets.
   You can then include the zip file as one of the artifacts.
 - The Python environment is located in `/srv/hops/anaconda/envs/hopsworks_environment`.
   It is a virtualenv rather than a conda environment, and the path is unchanged so existing scripts keep working.
   You can install or uninstall packages in it using pip like: `/srv/hops/anaconda/envs/hopsworks_environment/bin/pip install spotify==0.10.2`.
   If the command requires some input, write the command together with the expected input otherwise the build will fail.
+
+## Installing a compiler
+
+The PyTorch and Ray environments contain a C and C++ compiler, since they compile code at runtime for `torch.compile` and for CUDA extensions.
+The other environments do not, because `build-essential`, and every Ubuntu `-dev` package, depends on the Linux kernel headers, which account for most of the vulnerabilities reported against the images and are never patched within an Ubuntu release.
+
+In an environment without a compiler, a library that is published only as a source distribution fails to install:
+
+```text
+× Failed to build `thriftpy2==0.5.2`
+╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+    error: [Errno 2] No such file or directory: 'cc'
+```
+
+Install the compiler, build the library and remove the compiler again in the same script.
+The library keeps working, since what it needs at runtime are the shared libraries it links against, and the environment does not end up carrying the kernel headers.
+
+```bash
+#!/bin/bash
+set -e
+
+sudo apt-get update
+sudo apt-get install -y build-essential
+
+uv pip install --no-cache --python /srv/hops/anaconda/envs/hopsworks_environment/bin/python thriftpy2==0.5.2
+
+sudo apt-get purge -y --auto-remove build-essential
+sudo apt-get clean
+```
+
+Leave the purge out if you want to install more such libraries from the UI afterwards, or if the library loads a shared library owned by a `-dev` package you installed, since `--auto-remove` takes that with it.
+Do not purge in the PyTorch and Ray environments, where it would remove the compiler they came with.
 
 ## Making custom-command builds faster
 

--- a/docs/user_guides/projects/python/environment_history.md
+++ b/docs/user_guides/projects/python/environment_history.md
@@ -14,7 +14,8 @@ In this guide, you will learn how you can track the changes of your Python envir
 The Python environment evolves over time as libraries are installed, uninstalled, upgraded, and downgraded.
 To assist in tracking the changes in the environment, you can see the environment history in the UI.
 You can view what changes were introduced at each point a new environment was created.
-Hopsworks will keep a version of a YAML file for each environment so that if you want to restore an older environment you can use it.
+Hopsworks keeps a YAML file for each version of the environment, as a record of what that version contained.
+Importing such a file back into an environment is no longer supported, so to return to an earlier version, clone an environment and install the same packages again.
 To see the differences between environments click on the button as shown in figure 1. You will then see the difference between the environment and the previous environment it was created from.
 <p align="center">
   <figure>


### PR DESCRIPTION
Two commits.

## [HWORKS-2991][APPEND] Two docs claims left over from the conda era

The uv migration is already documented — the retired conda / `.egg` / `environment.yml` installs in `python_install.md`, and export-is-not-an-import in `python_env_export.md`. Two claims elsewhere were missed:

- **`concepts/dev/inside.md`** still listed conda channels as a source you can install dependencies from. The backend refuses that install, and refuses a conda-channel search too.
- **`environment_history.md`** said the per-version YAML file is kept "so that if you want to restore an older environment you can use it". Importing an `environment.yml` is no longer supported and the history API is read-only (`getAll` / `getEnvironmentDelta`, no restore endpoint), so the file is a record and nothing more.

## [HWORKS-3040] Installing a compiler

Documentation for [docker-images#926](https://github.com/logicalclocks/docker-images/pull/926), which removes `build-essential` and the `-dev` packages that pull in the kernel headers from the base images. Asked for on Slack as the condition for merging it: document the compiler issue, with a custom commands example for installing one.

One new section: which environments have a compiler and why the others do not, what the failure looks like, and a script that installs one, builds the library and purges it again so the environment does not end up carrying the kernel headers either. Plus when not to purge — more installs to follow, a `-dev` package that owns a shared library the wheel loads, or the PyTorch and Ray environments, which use their compiler at runtime.

Also `BUILD_PATH` → `BUILD_DIR` in the artifacts bullet: the generated Dockerfile sets `BUILD_DIR`, and nothing sets `BUILD_PATH`.

### Verified end to end on a cluster

The `python-feature-pipeline` base image in a cluster's registry was replaced with one built from docker-images#926 (`gcc`, `cc`, `build-essential` and `linux-libc-dev` all absent, confirmed from an `imagePullPolicy: Always` pod), and a project environment was cloned from it.

1. **Installing `thriftpy2==0.5.2` from the library API fails.** The environment build log ends with `error: [Errno 2] No such file or directory: 'cc'`, under uv's `× Failed to build` framing — the environment build installs with uv, so that is the error quoted here rather than pip's.
2. **The script in the docs, uploaded to HopsFS and run as a custom command, succeeds.** The environment goes to version `.1` with `thriftpy2 0.5.2`, `cython 3.3.0` and `ply 3.11` installed.
3. **The resulting environment image is clean.** No `gcc`, no `cc`, no `build-essential`, `linux-libc-dev` uninstalled, while `thriftpy2` imports and its compiled `cpython-312-x86_64-linux-gnu.so` extensions are present and load. `hopsworks`, `pandas` and `psycopg2` still import, and `/etc/sudoers.d` holds only `README`, so the `sudo` grant really is build-scoped as documented.

The script exactly as written here was also run verbatim as `yarnapp`, with the same `/etc/sudoers.d/yarnapp` grant the build creates, and exits 0 with the same end state.

`markdownlint-cli2` is clean. Backports to `branch-5.0` / `branch-4.8` are owed whenever #926 is backported, and not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[HWORKS-2991]: https://hopsworks.atlassian.net/browse/HWORKS-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HWORKS-3040]: https://hopsworks.atlassian.net/browse/HWORKS-3040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ